### PR TITLE
docs: Add required open source files and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Changes in this pull request
+<!-- Give a description of what has changed -->
+
+## Types of changes
+<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist
+- [ ] All applicable changes have been documented
+- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Adobe code of conduct
+
+## Our pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language.
+* Being respectful of differing viewpoints and experiences.
+* Gracefully accepting constructive criticism.
+* Focusing on what is best for the community.
+* Showing empathy towards other community members.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances.
+* Trolling, insulting/derogatory comments, and personal or political attacks.
+* Public or private harassment.
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission.
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Our responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at Grp-opensourceoffice@adobe.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the code of conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This code of conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [https://contributor-covenant.org/version/1/4][version].
+
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing
+
+We welcome contributions to this project!
+
+Before you start, we ask that you understand the following guidelines.
+
+## Code of conduct
+
+This project adheres to the Adobe [code of conduct](CODE_OF_CONDUCT.md). By participating,
+you are expected to uphold this code. Please report unacceptable behavior to
+[Grp-opensourceoffice@adobe.com](mailto:Grp-opensourceoffice@adobe.com).
+
+## Have a question?
+
+Start by filing an issue. The existing committers on this project work to reach
+consensus around project direction and issue solutions within issue threads
+(when appropriate).
+
+### Current areas of work
+
+Some broad categories of work (and thus things you might expect to change) are:
+
+* We'll be reviewing and refining our APIs for ease of use and comprehension. We'd appreciate feedback on areas that you find confusing or unnecessarily difficult.
+* We'll also be reviewing our APIs for compliance with best practices. 
+* Our documentation is incomplete. We'll be working on refining the documentation.
+* Our testing infrastructure is incomplete. We'll be working on improving test coverage, memory efficiency, and performance benchmarks.
+
+### Desired feedback
+
+We welcome feedback on:
+
+* API design
+* Prioritization of upcoming development, especially:
+  * File format support
+  * Assertion support
+* Optimizations and performance concerns
+* Bugs or non-compliance with the C2PA spec
+* Additional platform support
+
+## Contributor license agreement
+
+All third-party contributions to this project must be accompanied by a signed contributor
+license agreement. This gives Adobe permission to redistribute your contributions
+as part of the project. [Sign our CLA](https://opensource.adobe.com/cla.html). You
+only need to submit an Adobe CLA one time, so if you have submitted one previously,
+you are good to go!
+
+## Code reviews
+
+All submissions should come in the form of pull requests and need to be reviewed
+by project committers. Read [GitHub's pull request documentation](https://help.github.com/articles/about-pull-requests/)
+for more information on sending pull requests.
+
+Code submissions will need to pass all automated tests in place at the time of submission.
+These include such things as Rust code format, Clippy/lint checks, and unit test coverage.
+
+We encourage you to raise an issue in GitHub before starting work on a major addition to the crate.
+This will give us an opportunity to discuss API design and avoid duplicate efforts.
+
+### Pull request titles
+
+Titles of pull requests that target a long-lived branch such as _main_ or a release-specific branch should follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification). This means that the first word of the pull request title should be one of the following:
+
+  * `build`
+  * `chore`
+  * `ci`
+  * `docs`
+  * `feat`
+  * `fix`
+  * `perf`
+  * `refactor`
+  * `revert`
+  * `style`
+  * `test`
+
+Optionally, but preferred, a scope can be added in parentheses after the type. The scope should be the name of the module or component that the commit affects. For example, `feat(api): Introduce a new API to validate 1.0 claims`.
+
+If more detail is warranted, add a blank line and then continue with sentences (these sentences should be punctuated as such) and paragraphs as needed to provide that detail. There is no need to word-wrap this message.
+
+For example:
+
+```text
+feat(api): Introduce a new API to validate 1.0 claims
+
+Repurpose existing v2 API for 0.8 compatibility (read: no validation) mode.
+```
+
+The conventional commit message requirement does not apply to individual commits within a pull request, provided that those commits will be squashed when the PR is merged and the resulting squash commit does follow the conventional commit requirement. This may require the person merging the PR to verify the commit message syntax when performing the squash merge.
+
+TIP: For single-commit PRs, ensure the commit message conforms to the conventional commit requirement, since by default that will also be the title of the PR.
+
+## From contributor to committer
+
+We love contributions from our community! If you'd like to go a step beyond contributor
+and become a committer with full write access and a say in the project, you must
+be invited to the project. The existing committers employ an internal nomination
+process that must reach lazy consensus (silence is approval) before invitations
+are issued. If you feel you are qualified and want to get more deeply involved,
+feel free to reach out to existing committers to have a conversation about that.
+
+## Security issues
+
+Do not create a public GitHub issue for any suspected security vulnerabilities. Instead, please file an issue through [Adobe's HackerOne page](https://hackerone.com/adobe?type=team). 
+For more information on reporting security issues, see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security
+
+This C2PA open-source library is maintained in partnership with Adobe. At this time, Adobe is taking point on accepting security reports through its HackerOne portal and public bug bounty program.
+
+## Reporting a vulnerability
+
+Please do not create a public GitHub issue for any suspected security vulnerabilities. Instead, please file an issue through [Adobe's HackerOne page](https://hackerone.com/adobe?type=team). If for some reason this is not possible, reach out to cai-security@adobe.com.
+
+
+## Vulnerability SLAs
+
+Once we receive an actionable vulnerability (meaning there is an available patch, or a code fix is required), we will acknowledge the vulnerability within 24 hours. Our target SLAs for resolution are:
+
+1. 72 hours for vulnerabilities with a CVSS score of 9.0-10.0
+2. 2 weeks for vulnerabilities with a CVSS score of 7.0-8.9
+
+Any vulnerability with a score below 6.9 will be resolved when possible.
+
+
+## C2PA Vulnerabilities
+
+This library is not meant to address any potential vulnerabilities within the C2PA specification itself. It is only an implementation of the spec as written. Instead, report any suspected vulnerabilities within the spec [here](https://github.com/c2pa-org/specifications/issues).


### PR DESCRIPTION
This PR brings this repo in line with other repos in the contentauth org.

CODE_OF_CONDUCT.md, CONTRIBUTING.md, and SECURITY.md are required for Adobe OS projects.

.github/PULL_REQUEST_TEMPLATE.md will help ensure proper PRs.
