### PR TITLE
WIP: add ManifestBuilder package for simple, compliant manifest JSON generation

### DIFF
--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/AttestationBuilder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/AttestationBuilder.kt
@@ -1,0 +1,510 @@
+package org.contentauth.c2pa.manifest
+
+import org.json.JSONArray
+import org.json.JSONObject
+import java.text.SimpleDateFormat
+import java.util.*
+
+abstract class Attestation(val type: String) {
+    abstract fun toJsonObject(): JSONObject
+}
+
+class CreativeWorkAttestation : Attestation(C2PAAssertionTypes.CREATIVE_WORK) {
+    private val authors = mutableListOf<Author>()
+    private var dateCreated: String? = null
+    private var reviewStatus: String? = null
+
+    data class Author(
+        val name: String,
+        val credential: String? = null,
+        val identifier: String? = null
+    )
+
+    fun addAuthor(name: String, credential: String? = null, identifier: String? = null): CreativeWorkAttestation {
+        authors.add(Author(name, credential, identifier))
+        return this
+    }
+
+    fun dateCreated(date: Date): CreativeWorkAttestation {
+        val iso8601 = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+        this.dateCreated = iso8601.format(date)
+        return this
+    }
+
+    fun dateCreated(isoDateString: String): CreativeWorkAttestation {
+        this.dateCreated = isoDateString
+        return this
+    }
+
+    fun reviewStatus(status: String): CreativeWorkAttestation {
+        this.reviewStatus = status
+        return this
+    }
+
+    override fun toJsonObject(): JSONObject {
+        return JSONObject().apply {
+            if (authors.isNotEmpty()) {
+                put("author", JSONArray().apply {
+                    authors.forEach { author ->
+                        put(JSONObject().apply {
+                            put("name", author.name)
+                            author.credential?.let { put("credential", it) }
+                            author.identifier?.let { put("@id", it) }
+                        })
+                    }
+                })
+            }
+            dateCreated?.let { put("dateCreated", it) }
+            reviewStatus?.let { put("reviewStatus", it) }
+        }
+    }
+}
+
+class ActionsAttestation : Attestation("c2pa.actions") {
+    private val actionsList = mutableListOf<Action>()
+
+    fun addAction(action: Action): ActionsAttestation {
+        actionsList.add(action)
+        return this
+    }
+
+    fun addCreatedAction(softwareAgent: String? = null, whenTimestamp: String? = null): ActionsAttestation {
+        actionsList.add(Action(C2PAActions.CREATED, whenTimestamp, softwareAgent))
+        return this
+    }
+
+    fun addEditedAction(softwareAgent: String? = null, whenTimestamp: String? = null, changes: List<ActionChange> = emptyList()): ActionsAttestation {
+        actionsList.add(Action(C2PAActions.EDITED, whenTimestamp, softwareAgent, changes))
+        return this
+    }
+
+    fun addOpenedAction(softwareAgent: String? = null, whenTimestamp: String? = null): ActionsAttestation {
+        actionsList.add(Action(C2PAActions.OPENED, whenTimestamp, softwareAgent))
+        return this
+    }
+
+    fun addPlacedAction(softwareAgent: String? = null, whenTimestamp: String? = null): ActionsAttestation {
+        actionsList.add(Action(C2PAActions.PLACED, whenTimestamp, softwareAgent))
+        return this
+    }
+
+    fun addDrawingAction(softwareAgent: String? = null, whenTimestamp: String? = null): ActionsAttestation {
+        actionsList.add(Action(C2PAActions.DRAWING, whenTimestamp, softwareAgent))
+        return this
+    }
+
+    fun addColorAdjustmentsAction(softwareAgent: String? = null, whenTimestamp: String? = null, parameters: Map<String, Any> = emptyMap()): ActionsAttestation {
+        actionsList.add(Action(C2PAActions.COLOR_ADJUSTMENTS, whenTimestamp, softwareAgent, emptyList(), null, parameters))
+        return this
+    }
+
+    fun addResizedAction(softwareAgent: String? = null, whenTimestamp: String? = null): ActionsAttestation {
+        actionsList.add(Action(C2PAActions.RESIZED, whenTimestamp, softwareAgent))
+        return this
+    }
+
+    override fun toJsonObject(): JSONObject {
+        return JSONObject().apply {
+            put("actions", JSONArray().apply {
+                actionsList.forEach { action ->
+                    put(JSONObject().apply {
+                        put("action", action.action)
+                        action.whenTimestamp?.let { put("when", it) }
+                        action.softwareAgent?.let { put("softwareAgent", it) }
+                        action.reason?.let { put("reason", it) }
+                        
+                        if (action.changes.isNotEmpty()) {
+                            put("changes", JSONArray().apply {
+                                action.changes.forEach { change ->
+                                    put(JSONObject().apply {
+                                        put("field", change.field)
+                                        put("description", change.description)
+                                    })
+                                }
+                            })
+                        }
+                        
+                        if (action.parameters.isNotEmpty()) {
+                            val params = JSONObject()
+                            action.parameters.forEach { (key, value) ->
+                                params.put(key, value)
+                            }
+                            put("parameters", params)
+                        }
+                    })
+                }
+            })
+        }
+    }
+}
+
+class AssertionMetadataAttestation : Attestation("c2pa.assertion.metadata") {
+    private val metadata = mutableMapOf<String, Any>()
+
+    fun addMetadata(key: String, value: Any): AssertionMetadataAttestation {
+        metadata[key] = value
+        return this
+    }
+
+    fun dateTime(dateTime: String): AssertionMetadataAttestation {
+        metadata["dateTime"] = dateTime
+        return this
+    }
+
+    fun location(location: JSONObject): AssertionMetadataAttestation {
+        metadata["location"] = location
+        return this
+    }
+
+    fun device(device: String): AssertionMetadataAttestation {
+        metadata["device"] = device
+        return this
+    }
+
+    override fun toJsonObject(): JSONObject {
+        val json = JSONObject()
+        metadata.forEach { (key, value) ->
+            when (value) {
+                is JSONObject, is JSONArray -> json.put(key, value)
+                is String -> json.put(key, value)
+                is Number -> json.put(key, value)
+                is Boolean -> json.put(key, value)
+                else -> json.put(key, value.toString())
+            }
+        }
+        return json
+    }
+}
+
+class ThumbnailAttestation : Attestation("c2pa.thumbnail") {
+    private var format: String? = null
+    private var identifier: String? = null
+    private var contentType: String = "image/jpeg"
+
+    fun format(format: String): ThumbnailAttestation {
+        this.format = format
+        return this
+    }
+
+    fun identifier(identifier: String): ThumbnailAttestation {
+        this.identifier = identifier
+        return this
+    }
+
+    fun contentType(contentType: String): ThumbnailAttestation {
+        this.contentType = contentType
+        return this
+    }
+
+    override fun toJsonObject(): JSONObject {
+        return JSONObject().apply {
+            format?.let { put("format", it) }
+            identifier?.let { put("identifier", it) }
+            put("contentType", contentType)
+        }
+    }
+}
+
+class DataHashAttestation : Attestation("c2pa.data_hash") {
+    private var exclusions: List<Map<String, Any>> = emptyList()
+    private var name: String = "jumbf manifest"
+    private var pad: Int? = null
+
+    fun exclusions(exclusions: List<Map<String, Any>>): DataHashAttestation {
+        this.exclusions = exclusions
+        return this
+    }
+
+    fun name(name: String): DataHashAttestation {
+        this.name = name
+        return this
+    }
+
+    fun pad(pad: Int): DataHashAttestation {
+        this.pad = pad
+        return this
+    }
+
+    override fun toJsonObject(): JSONObject {
+        return JSONObject().apply {
+            if (exclusions.isNotEmpty()) {
+                put("exclusions", JSONArray().apply {
+                    exclusions.forEach { exclusion ->
+                        put(JSONObject().apply {
+                            exclusion.forEach { (key, value) ->
+                                put(key, value)
+                            }
+                        })
+                    }
+                })
+            }
+            put("name", name)
+            pad?.let { put("pad", it) }
+        }
+    }
+}
+
+data class VerifiedIdentity(
+    val type: String,
+    val username: String,
+    val uri: String,
+    val verifiedAt: String,
+    val provider: IdentityProvider
+)
+
+data class IdentityProvider(
+    val id: String,
+    val name: String
+)
+
+data class CredentialSchema(
+    val id: String = "https://cawg.io/identity/1.1/ica/schema/",
+    val type: String = "JSONSchema"
+)
+
+class CAWGIdentityAttestation : Attestation(C2PAAssertionTypes.CAWG_IDENTITY) {
+    private val contexts = mutableListOf(
+        "https://www.w3.org/ns/credentials/v2",
+        "https://cawg.io/identity/1.1/ica/context/"
+    )
+    private val types = mutableListOf("VerifiableCredential", "IdentityClaimsAggregationCredential")
+    private var issuer: String = "did:web:connected-identities.identity.adobe.com"
+    private var validFrom: String? = null
+    private val verifiedIdentities = mutableListOf<VerifiedIdentity>()
+    private val credentialSchemas = mutableListOf<CredentialSchema>()
+
+    init {
+        credentialSchemas.add(CredentialSchema())
+    }
+
+    fun issuer(issuer: String): CAWGIdentityAttestation {
+        this.issuer = issuer
+        return this
+    }
+
+    fun validFrom(validFrom: String): CAWGIdentityAttestation {
+        this.validFrom = validFrom
+        return this
+    }
+
+    fun validFromNow(): CAWGIdentityAttestation {
+        val iso8601 = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+        this.validFrom = iso8601.format(Date())
+        return this
+    }
+
+    fun addContext(context: String): CAWGIdentityAttestation {
+        if (!contexts.contains(context)) {
+            contexts.add(context)
+        }
+        return this
+    }
+
+    fun addType(type: String): CAWGIdentityAttestation {
+        if (!types.contains(type)) {
+            types.add(type)
+        }
+        return this
+    }
+
+    fun addVerifiedIdentity(
+        type: String,
+        username: String,
+        uri: String,
+        verifiedAt: String,
+        providerId: String,
+        providerName: String
+    ): CAWGIdentityAttestation {
+        verifiedIdentities.add(
+            VerifiedIdentity(
+                type = type,
+                username = username,
+                uri = uri,
+                verifiedAt = verifiedAt,
+                provider = IdentityProvider(providerId, providerName)
+            )
+        )
+        return this
+    }
+
+    fun addSocialMediaIdentity(
+        username: String,
+        uri: String,
+        verifiedAt: String,
+        providerId: String,
+        providerName: String
+    ): CAWGIdentityAttestation {
+        return addVerifiedIdentity(CAWGIdentityTypes.SOCIAL_MEDIA, username, uri, verifiedAt, providerId, providerName)
+    }
+
+    fun addInstagramIdentity(username: String, verifiedAt: String): CAWGIdentityAttestation {
+        return addSocialMediaIdentity(
+            username = username,
+            uri = "https://www.instagram.com/$username",
+            verifiedAt = verifiedAt,
+            providerId = CAWGProviders.INSTAGRAM,
+            providerName = "instagram"
+        )
+    }
+
+    fun addTwitterIdentity(username: String, verifiedAt: String): CAWGIdentityAttestation {
+        return addSocialMediaIdentity(
+            username = username,
+            uri = "https://twitter.com/$username",
+            verifiedAt = verifiedAt,
+            providerId = CAWGProviders.TWITTER,
+            providerName = "twitter"
+        )
+    }
+
+    fun addLinkedInIdentity(displayName: String, profileUrl: String, verifiedAt: String): CAWGIdentityAttestation {
+        return addSocialMediaIdentity(
+            username = displayName,
+            uri = profileUrl,
+            verifiedAt = verifiedAt,
+            providerId = CAWGProviders.LINKEDIN,
+            providerName = "linkedin"
+        )
+    }
+
+    fun addBehanceIdentity(username: String, verifiedAt: String): CAWGIdentityAttestation {
+        return addSocialMediaIdentity(
+            username = username,
+            uri = "https://www.behance.net/$username",
+            verifiedAt = verifiedAt,
+            providerId = CAWGProviders.BEHANCE,
+            providerName = "behance"
+        )
+    }
+
+    fun addYouTubeIdentity(channelName: String, channelUrl: String, verifiedAt: String): CAWGIdentityAttestation {
+        return addSocialMediaIdentity(
+            username = channelName,
+            uri = channelUrl,
+            verifiedAt = verifiedAt,
+            providerId = CAWGProviders.YOUTUBE,
+            providerName = "youtube"
+        )
+    }
+
+    fun addGitHubIdentity(username: String, verifiedAt: String): CAWGIdentityAttestation {
+        return addSocialMediaIdentity(
+            username = username,
+            uri = "https://github.com/$username",
+            verifiedAt = verifiedAt,
+            providerId = CAWGProviders.GITHUB,
+            providerName = "github"
+        )
+    }
+
+    fun addCredentialSchema(id: String, type: String): CAWGIdentityAttestation {
+        credentialSchemas.add(CredentialSchema(id, type))
+        return this
+    }
+
+    override fun toJsonObject(): JSONObject {
+        return JSONObject().apply {
+            put("@context", JSONArray(contexts))
+            put("type", JSONArray(types))
+            put("issuer", issuer)
+            validFrom?.let { put("validFrom", it) }
+
+            if (verifiedIdentities.isNotEmpty()) {
+                put("verifiedIdentities", JSONArray().apply {
+                    verifiedIdentities.forEach { identity ->
+                        put(JSONObject().apply {
+                            put("type", identity.type)
+                            put("username", identity.username)
+                            put("uri", identity.uri)
+                            put("verifiedAt", identity.verifiedAt)
+                            put("provider", JSONObject().apply {
+                                put("id", identity.provider.id)
+                                put("name", identity.provider.name)
+                            })
+                        })
+                    }
+                })
+            }
+
+            if (credentialSchemas.isNotEmpty()) {
+                put("credentialSchema", JSONArray().apply {
+                    credentialSchemas.forEach { schema ->
+                        put(JSONObject().apply {
+                            put("id", schema.id)
+                            put("type", schema.type)
+                        })
+                    }
+                })
+            }
+        }
+    }
+}
+
+class AttestationBuilder {
+    private val attestations = mutableListOf<Attestation>()
+
+    fun addCreativeWork(configure: CreativeWorkAttestation.() -> Unit): AttestationBuilder {
+        val attestation = CreativeWorkAttestation()
+        attestation.configure()
+        attestations.add(attestation)
+        return this
+    }
+
+    fun addActions(configure: ActionsAttestation.() -> Unit): AttestationBuilder {
+        val attestation = ActionsAttestation()
+        attestation.configure()
+        attestations.add(attestation)
+        return this
+    }
+
+    fun addAssertionMetadata(configure: AssertionMetadataAttestation.() -> Unit): AttestationBuilder {
+        val attestation = AssertionMetadataAttestation()
+        attestation.configure()
+        attestations.add(attestation)
+        return this
+    }
+
+    fun addThumbnail(configure: ThumbnailAttestation.() -> Unit): AttestationBuilder {
+        val attestation = ThumbnailAttestation()
+        attestation.configure()
+        attestations.add(attestation)
+        return this
+    }
+
+    fun addDataHash(configure: DataHashAttestation.() -> Unit): AttestationBuilder {
+        val attestation = DataHashAttestation()
+        attestation.configure()
+        attestations.add(attestation)
+        return this
+    }
+
+    fun addCAWGIdentity(configure: CAWGIdentityAttestation.() -> Unit): AttestationBuilder {
+        val attestation = CAWGIdentityAttestation()
+        attestation.configure()
+        attestations.add(attestation)
+        return this
+    }
+
+    fun addCustomAttestation(type: String, data: JSONObject): AttestationBuilder {
+        attestations.add(object : Attestation(type) {
+            override fun toJsonObject(): JSONObject = data
+        })
+        return this
+    }
+
+    fun build(): Map<String, JSONObject> {
+        return attestations.associate { it.type to it.toJsonObject() }
+    }
+
+    fun buildForManifest(manifestBuilder: ManifestBuilder): ManifestBuilder {
+        val builtAttestations = build()
+        builtAttestations.forEach { (type, data) ->
+            manifestBuilder.addAssertion(type, data)
+        }
+        return manifestBuilder
+    }
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/C2PAActions.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/C2PAActions.kt
@@ -1,0 +1,102 @@
+package org.contentauth.c2pa.manifest
+
+object C2PAActions {
+    const val CREATED = "c2pa.created"
+    const val EDITED = "c2pa.edited"
+    const val OPENED = "c2pa.opened"
+    const val PLACED = "c2pa.placed"
+    const val DRAWING = "c2pa.drawing"
+    const val COLOR_ADJUSTMENTS = "c2pa.color_adjustments"
+    const val RESIZED = "c2pa.resized"
+    const val CROPPED = "c2pa.cropped"
+    const val FILTERED = "c2pa.filtered"
+    const val ORIENTATION = "c2pa.orientation"
+    const val TRANSCODED = "c2pa.transcoded"
+    const val RECOMPRESSED = "c2pa.recompressed"
+    const val VERSION_CREATED = "c2pa.version_created"
+    const val CONVERTED = "c2pa.converted"
+    const val PRODUCED = "c2pa.produced"
+    const val PUBLISHED = "c2pa.published"
+    const val REDACTED = "c2pa.redacted"
+
+    object Adobe {
+        const val PHOTOSHOP_EDITED = "adobe.photoshop.edited"
+        const val ILLUSTRATOR_EDITED = "adobe.illustrator.edited"
+        const val INDESIGN_EDITED = "adobe.indesign.edited"
+        const val LIGHTROOM_EDITED = "adobe.lightroom.edited"
+        const val PREMIERE_EDITED = "adobe.premiere.edited"
+        const val AFTER_EFFECTS_EDITED = "adobe.after_effects.edited"
+    }
+}
+
+object C2PAAssertionTypes {
+    const val CREATIVE_WORK = "c2pa.creative_work"
+    const val ACTIONS = "c2pa.actions"
+    const val ASSERTION_METADATA = "c2pa.assertion.metadata"
+    const val THUMBNAIL = "c2pa.thumbnail"
+    const val DATA_HASH = "c2pa.data_hash"
+    const val HASH_DATA = "c2pa.hash.data"
+    const val BMFF_HASH = "c2pa.hash.bmff"
+    const val EXIF = "stds.exif"
+    const val IPTC = "stds.iptc"
+    const val XMP = "stds.xmp"
+    const val SCHEMA_ORG_CREATIVE_WORK = "stds.schema-org.CreativeWork"
+    const val INGREDIENT = "c2pa.ingredient"
+    const val CAWG_IDENTITY = "cawg.identity"
+}
+
+object CAWGIdentityTypes {
+    const val SOCIAL_MEDIA = "cawg.social_media"
+    const val EMAIL = "cawg.email"
+    const val PHONE = "cawg.phone"
+    const val WEBSITE = "cawg.website"
+    const val PROFESSIONAL = "cawg.professional"
+}
+
+object CAWGProviders {
+    const val INSTAGRAM = "https://instagram.com"
+    const val BEHANCE = "https://behance.net"
+    const val LINKEDIN = "https://linkedin.com"
+    const val TWITTER = "https://twitter.com"
+    const val FACEBOOK = "https://facebook.com"
+    const val YOUTUBE = "https://youtube.com"
+    const val TIKTOK = "https://tiktok.com"
+    const val SNAPCHAT = "https://snapchat.com"
+    const val PINTEREST = "https://pinterest.com"
+    const val GITHUB = "https://github.com"
+    const val DRIBBBLE = "https://dribbble.com"
+    const val ARTSTATION = "https://artstation.com"
+}
+
+object C2PAFormats {
+    const val JPEG = "image/jpeg"
+    const val PNG = "image/png"
+    const val WEBP = "image/webp"
+    const val TIFF = "image/tiff"
+    const val HEIF = "image/heif"
+    const val AVIF = "image/avif"
+    const val MP4 = "video/mp4"
+    const val MOV = "video/quicktime"
+    const val AVI = "video/x-msvideo"
+    const val PDF = "application/pdf"
+    const val SVG = "image/svg+xml"
+    const val GIF = "image/gif"
+    const val BMP = "image/bmp"
+    const val WEBM = "video/webm"
+    const val OGG = "video/ogg"
+    const val MKV = "video/x-matroska"
+}
+
+object C2PARelationships {
+    const val PARENT_OF = "parentOf"
+    const val COMPONENT_OF = "componentOf"
+    const val INGREDIENT_OF = "ingredientOf"
+    const val ALTERNATE_OF = "alternateOf"
+}
+
+object TimestampAuthorities {
+    const val DIGICERT = "http://timestamp.digicert.com"
+    const val SECTIGO = "http://timestamp.sectigo.com"
+    const val GLOBALSIGN = "http://timestamp.globalsign.com/tsa/r6advanced1"
+    const val ENTRUST = "http://timestamp.entrust.net/TSS/RFC3161sha2TS"
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ManifestBuilder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ManifestBuilder.kt
@@ -1,0 +1,243 @@
+package org.contentauth.c2pa.manifest
+
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.*
+
+data class ClaimGenerator(
+    val name: String,
+    val version: String,
+    val icon: String? = null
+)
+
+data class Ingredient(
+    val title: String? = null,
+    val format: String,
+    val instanceId: String = UUID.randomUUID().toString(),
+    val documentId: String? = null,
+    val provenance: String? = null,
+    val hash: String? = null,
+    val relationship: String = "parentOf",
+    val validationStatus: List<String> = emptyList(),
+    val thumbnail: Thumbnail? = null
+)
+
+data class Thumbnail(
+    val format: String,
+    val identifier: String,
+    val contentType: String = "image/jpeg"
+)
+
+data class Action(
+    val action: String,
+    val whenTimestamp: String? = null,
+    val softwareAgent: String? = null,
+    val changes: List<ActionChange> = emptyList(),
+    val reason: String? = null,
+    val parameters: Map<String, Any> = emptyMap()
+)
+
+data class ActionChange(
+    val field: String,
+    val description: String
+)
+
+class ManifestBuilder {
+    private var claimGenerator: ClaimGenerator? = null
+    private var format: String? = null
+    private var title: String? = null
+    private var instanceId: String = UUID.randomUUID().toString()
+    private var documentId: String? = null
+    private val ingredients = mutableListOf<Ingredient>()
+    private val actions = mutableListOf<Action>()
+    private val assertions = mutableMapOf<String, Any>()
+    private var thumbnail: Thumbnail? = null
+    private var producer: String? = null
+    private var taUrl: String? = null
+
+    fun claimGenerator(name: String, version: String, icon: String? = null): ManifestBuilder {
+        this.claimGenerator = ClaimGenerator(name, version, icon)
+        return this
+    }
+
+    fun format(format: String): ManifestBuilder {
+        this.format = format
+        return this
+    }
+
+    fun title(title: String): ManifestBuilder {
+        this.title = title
+        return this
+    }
+
+    fun instanceId(instanceId: String): ManifestBuilder {
+        this.instanceId = instanceId
+        return this
+    }
+
+    fun documentId(documentId: String): ManifestBuilder {
+        this.documentId = documentId
+        return this
+    }
+
+    fun producer(producer: String): ManifestBuilder {
+        this.producer = producer
+        return this
+    }
+
+    fun timestampAuthorityUrl(taUrl: String): ManifestBuilder {
+        this.taUrl = taUrl
+        return this
+    }
+
+    fun addIngredient(ingredient: Ingredient): ManifestBuilder {
+        ingredients.add(ingredient)
+        return this
+    }
+
+    fun addAction(action: Action): ManifestBuilder {
+        actions.add(action)
+        return this
+    }
+
+    fun addThumbnail(thumbnail: Thumbnail): ManifestBuilder {
+        this.thumbnail = thumbnail
+        return this
+    }
+
+    fun addAssertion(type: String, data: Any): ManifestBuilder {
+        assertions[type] = data
+        return this
+    }
+
+    fun build(): JSONObject {
+        val manifest = JSONObject()
+
+        // Add claim version
+        manifest.put("claim_version", 1)
+        
+        // Add timestamp authority URL if present
+        taUrl?.let { manifest.put("ta_url", it) }
+
+        // Add basic manifest fields
+        format?.let { manifest.put("format", it) }
+        title?.let { manifest.put("title", it) }
+        manifest.put("instanceID", instanceId)
+        documentId?.let { manifest.put("documentID", it) }
+        producer?.let { manifest.put("producer", it) }
+
+        // Add claim generator info as array
+        claimGenerator?.let { generator ->
+            manifest.put("claim_generator_info", JSONArray().apply {
+                put(JSONObject().apply {
+                    put("name", generator.name)
+                    put("version", generator.version)
+                    generator.icon?.let { put("icon", it) }
+                })
+            })
+        }
+
+        // Add thumbnail
+        thumbnail?.let { thumb ->
+            manifest.put("thumbnail", JSONObject().apply {
+                put("format", thumb.format)
+                put("identifier", thumb.identifier)
+            })
+        }
+
+        // Add ingredients
+        if (ingredients.isNotEmpty()) {
+            manifest.put("ingredients", JSONArray().apply {
+                ingredients.forEach { ingredient ->
+                    put(JSONObject().apply {
+                        ingredient.title?.let { put("title", it) }
+                        put("format", ingredient.format)
+                        put("instanceID", ingredient.instanceId)
+                        ingredient.documentId?.let { put("documentID", it) }
+                        ingredient.provenance?.let { put("provenance", it) }
+                        ingredient.hash?.let { put("hash", it) }
+                        put("relationship", ingredient.relationship)
+                        
+                        if (ingredient.validationStatus.isNotEmpty()) {
+                            put("validationStatus", JSONArray(ingredient.validationStatus))
+                        }
+                        
+                        ingredient.thumbnail?.let { thumb ->
+                            put("thumbnail", JSONObject().apply {
+                                put("format", thumb.format)
+                                put("identifier", thumb.identifier)
+                            })
+                        }
+                    })
+                }
+            })
+        }
+
+        // Build assertions array
+        val assertionsArray = JSONArray()
+
+        // Add actions as an assertion if present
+        if (actions.isNotEmpty()) {
+            assertionsArray.put(JSONObject().apply {
+                put("label", "c2pa.actions")
+                put("data", JSONObject().apply {
+                    put("actions", JSONArray().apply {
+                        actions.forEach { action ->
+                            put(JSONObject().apply {
+                                put("action", action.action)
+                                action.whenTimestamp?.let { put("when", it) }
+                                action.softwareAgent?.let { put("softwareAgent", it) }
+                                action.reason?.let { put("reason", it) }
+                                
+                                if (action.changes.isNotEmpty()) {
+                                    put("changes", JSONArray().apply {
+                                        action.changes.forEach { change ->
+                                            put(JSONObject().apply {
+                                                put("field", change.field)
+                                                put("description", change.description)
+                                            })
+                                        }
+                                    })
+                                }
+                                
+                                if (action.parameters.isNotEmpty()) {
+                                    val params = JSONObject()
+                                    action.parameters.forEach { (key, value) ->
+                                        params.put(key, value)
+                                    }
+                                    put("parameters", params)
+                                }
+                            })
+                        }
+                    })
+                })
+            })
+        }
+
+        // Add other assertions
+        assertions.forEach { (label, data) ->
+            assertionsArray.put(JSONObject().apply {
+                put("label", label)
+                when (data) {
+                    is JSONObject -> put("data", data)
+                    is JSONArray -> put("data", data)
+                    is String -> put("data", data)
+                    is Number -> put("data", data)
+                    is Boolean -> put("data", data)
+                    else -> put("data", data.toString())
+                }
+            })
+        }
+
+        // Add assertions array if not empty
+        if (assertionsArray.length() > 0) {
+            manifest.put("assertions", assertionsArray)
+        }
+
+        return manifest
+    }
+
+    fun buildJson(): String {
+        return build().toString(2)
+    }
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ManifestHelpers.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ManifestHelpers.kt
@@ -1,0 +1,401 @@
+package org.contentauth.c2pa.manifest
+
+import org.json.JSONObject
+import java.text.SimpleDateFormat
+import java.util.*
+
+object  ManifestHelpers {
+    
+    fun createBasicImageManifest(
+        title: String,
+        format: String = C2PAFormats.JPEG,
+        claimGeneratorName: String = "Android C2PA SDK",
+        claimGeneratorVersion: String = "1.0.0",
+        timestampAuthorityUrl: String? = null
+    ): ManifestBuilder {
+        val builder = ManifestBuilder()
+            .title(title)
+            .format(format)
+            .claimGenerator(claimGeneratorName, claimGeneratorVersion)
+        
+        timestampAuthorityUrl?.let { builder.timestampAuthorityUrl(it) }
+        return builder
+    }
+
+    fun createImageEditManifest(
+        title: String,
+        originalIngredientTitle: String,
+        originalFormat: String = C2PAFormats.JPEG,
+        format: String = C2PAFormats.JPEG,
+        softwareAgent: String? = null,
+        claimGeneratorName: String = "Android C2PA SDK",
+        claimGeneratorVersion: String = "1.0.0"
+    ): ManifestBuilder {
+        val ingredient = Ingredient(
+            title = originalIngredientTitle,
+            format = originalFormat,
+            relationship = C2PARelationships.PARENT_OF
+        )
+        
+        return ManifestBuilder()
+            .title(title)
+            .format(format)
+            .claimGenerator(claimGeneratorName, claimGeneratorVersion)
+            .addIngredient(ingredient)
+            .addAction(Action(
+                action = C2PAActions.EDITED,
+                whenTimestamp = getCurrentTimestamp(),
+                softwareAgent = softwareAgent
+            ))
+    }
+
+    fun createPhotoManifest(
+        title: String,
+        format: String = C2PAFormats.JPEG,
+        authorName: String? = null,
+        deviceName: String? = null,
+        location: JSONObject? = null,
+        claimGeneratorName: String = "Android C2PA SDK",
+        claimGeneratorVersion: String = "1.0.0"
+    ): ManifestBuilder {
+        val builder = ManifestBuilder()
+            .title(title)
+            .format(format)
+            .claimGenerator(claimGeneratorName, claimGeneratorVersion)
+            .addAction(Action(
+                action = C2PAActions.CREATED,
+                whenTimestamp = getCurrentTimestamp(),
+                softwareAgent = deviceName
+            ))
+
+        if (authorName != null || deviceName != null || location != null) {
+            val attestationBuilder = AttestationBuilder()
+            
+            if (authorName != null) {
+                attestationBuilder.addCreativeWork {
+                    addAuthor(authorName)
+                    dateCreated(Date())
+                }
+            }
+            
+            attestationBuilder.addAssertionMetadata {
+                dateTime(getCurrentTimestamp())
+                deviceName?.let { device(it) }
+                location?.let { location(it) }
+            }
+            
+            attestationBuilder.buildForManifest(builder)
+        }
+
+        return builder
+    }
+
+    fun createVideoEditManifest(
+        title: String,
+        originalIngredientTitle: String,
+        originalFormat: String = C2PAFormats.MP4,
+        format: String = C2PAFormats.MP4,
+        editingSoftware: String? = null,
+        editActions: List<String> = emptyList(),
+        claimGeneratorName: String = "Android C2PA SDK",
+        claimGeneratorVersion: String = "1.0.0"
+    ): ManifestBuilder {
+        val ingredient = Ingredient(
+            title = originalIngredientTitle,
+            format = originalFormat,
+            relationship = C2PARelationships.PARENT_OF
+        )
+        
+        val builder = ManifestBuilder()
+            .title(title)
+            .format(format)
+            .claimGenerator(claimGeneratorName, claimGeneratorVersion)
+            .addIngredient(ingredient)
+
+        val timestamp = getCurrentTimestamp()
+        
+        builder.addAction(Action(
+            action = C2PAActions.OPENED,
+            whenTimestamp = timestamp,
+            softwareAgent = editingSoftware
+        ))
+
+        editActions.forEach { actionType ->
+            builder.addAction(Action(
+                action = actionType,
+                whenTimestamp = timestamp,
+                softwareAgent = editingSoftware
+            ))
+        }
+
+        return builder
+    }
+
+    fun createCompositeManifest(
+        title: String,
+        format: String = C2PAFormats.JPEG,
+        ingredients: List<Ingredient>,
+        compositingSoftware: String? = null,
+        claimGeneratorName: String = "Android C2PA SDK",
+        claimGeneratorVersion: String = "1.0.0"
+    ): ManifestBuilder {
+        val builder = ManifestBuilder()
+            .title(title)
+            .format(format)
+            .claimGenerator(claimGeneratorName, claimGeneratorVersion)
+            .addAction(Action(
+                action = C2PAActions.CREATED,
+                whenTimestamp = getCurrentTimestamp(),
+                softwareAgent = compositingSoftware
+            ))
+
+        ingredients.forEach { ingredient ->
+            builder.addIngredient(ingredient)
+            builder.addAction(Action(
+                action = C2PAActions.PLACED,
+                whenTimestamp = getCurrentTimestamp(),
+                softwareAgent = compositingSoftware
+            ))
+        }
+
+        return builder
+    }
+
+    fun createScreenshotManifest(
+        deviceName: String,
+        appName: String? = null,
+        format: String = C2PAFormats.PNG,
+        claimGeneratorName: String = "Android C2PA SDK",
+        claimGeneratorVersion: String = "1.0.0"
+    ): ManifestBuilder {
+        val builder = ManifestBuilder()
+            .title("Screenshot")
+            .format(format)
+            .claimGenerator(claimGeneratorName, claimGeneratorVersion)
+            .producer(deviceName)
+            .addAction(Action(
+                action = C2PAActions.CREATED,
+                whenTimestamp = getCurrentTimestamp(),
+                softwareAgent = appName ?: "Screenshot"
+            ))
+
+        val attestationBuilder = AttestationBuilder()
+        attestationBuilder.addAssertionMetadata {
+            device(deviceName)
+            dateTime(getCurrentTimestamp())
+            addMetadata("capture_method", "screenshot")
+            appName?.let { addMetadata("source_application", it) }
+        }
+        
+        attestationBuilder.buildForManifest(builder)
+        return builder
+    }
+
+    fun createSocialMediaShareManifest(
+        originalTitle: String,
+        platform: String,
+        originalFormat: String = C2PAFormats.JPEG,
+        format: String = C2PAFormats.JPEG,
+        claimGeneratorName: String = "Android C2PA SDK",
+        claimGeneratorVersion: String = "1.0.0"
+    ): ManifestBuilder {
+        val ingredient = Ingredient(
+            title = originalTitle,
+            format = originalFormat,
+            relationship = C2PARelationships.PARENT_OF
+        )
+        
+        return ManifestBuilder()
+            .title("Shared on $platform")
+            .format(format)
+            .claimGenerator(claimGeneratorName, claimGeneratorVersion)
+            .addIngredient(ingredient)
+            .addAction(Action(
+                action = C2PAActions.RECOMPRESSED,
+                whenTimestamp = getCurrentTimestamp(),
+                softwareAgent = platform,
+                reason = "Social media optimization"
+            ))
+            .addAction(Action(
+                action = C2PAActions.PUBLISHED,
+                whenTimestamp = getCurrentTimestamp(),
+                softwareAgent = platform
+            ))
+    }
+
+    fun createFilteredImageManifest(
+        originalTitle: String,
+        filterName: String,
+        originalFormat: String = C2PAFormats.JPEG,
+        format: String = C2PAFormats.JPEG,
+        appName: String? = null,
+        claimGeneratorName: String = "Android C2PA SDK",
+        claimGeneratorVersion: String = "1.0.0"
+    ): ManifestBuilder {
+        val ingredient = Ingredient(
+            title = originalTitle,
+            format = originalFormat,
+            relationship = C2PARelationships.PARENT_OF
+        )
+        
+        val filterParameters = mapOf(
+            "filter_name" to filterName,
+            "filter_type" to "digital_filter"
+        )
+        
+        return ManifestBuilder()
+            .title("$originalTitle (Filtered)")
+            .format(format)
+            .claimGenerator(claimGeneratorName, claimGeneratorVersion)
+            .addIngredient(ingredient)
+            .addAction(Action(
+                action = C2PAActions.FILTERED,
+                whenTimestamp = getCurrentTimestamp(),
+                softwareAgent = appName,
+                parameters = filterParameters
+            ))
+    }
+
+    private fun getCurrentTimestamp(): String {
+        val iso8601 = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+        return iso8601.format(Date())
+    }
+
+    fun createLocation(latitude: Double, longitude: Double, name: String? = null): JSONObject {
+        return JSONObject().apply {
+            put("@type", "Place")
+            put("latitude", latitude)
+            put("longitude", longitude)
+            name?.let { put("name", it) }
+        }
+    }
+
+    fun createGeoLocation(
+        latitude: Double,
+        longitude: Double,
+        altitude: Double? = null,
+        accuracy: Double? = null
+    ): JSONObject {
+        return JSONObject().apply {
+            put("@type", "GeoCoordinates")
+            put("latitude", latitude)
+            put("longitude", longitude)
+            altitude?.let { put("elevation", it) }
+            accuracy?.let { put("accuracy", it) }
+        }
+    }
+
+    fun addStandardThumbnail(
+        manifestBuilder: ManifestBuilder,
+        thumbnailIdentifier: String = "thumbnail.jpg",
+        format: String = C2PAFormats.JPEG
+    ): ManifestBuilder {
+        return manifestBuilder.addThumbnail(
+            Thumbnail(
+                format = format,
+                identifier = thumbnailIdentifier,
+                contentType = format
+            )
+        )
+    }
+
+    fun createCreatorVerifiedManifest(
+        title: String,
+        format: String = C2PAFormats.JPEG,
+        authorName: String? = null,
+        deviceName: String? = null,
+        location: JSONObject? = null,
+        creatorIdentities: List<VerifiedIdentity> = emptyList(),
+        claimGeneratorName: String = "Android C2PA SDK",
+        claimGeneratorVersion: String = "1.0.0"
+    ): ManifestBuilder {
+        val builder = ManifestBuilder()
+            .title(title)
+            .format(format)
+            .claimGenerator(claimGeneratorName, claimGeneratorVersion)
+            .addAction(Action(
+                action = C2PAActions.CREATED,
+                whenTimestamp = getCurrentTimestamp(),
+                softwareAgent = deviceName
+            ))
+
+        val attestationBuilder = AttestationBuilder()
+
+        if (authorName != null) {
+            attestationBuilder.addCreativeWork {
+                addAuthor(authorName)
+                dateCreated(Date())
+            }
+        }
+
+        if (creatorIdentities.isNotEmpty()) {
+            attestationBuilder.addCAWGIdentity {
+                validFromNow()
+                creatorIdentities.forEach { identity ->
+                    addVerifiedIdentity(
+                        type = identity.type,
+                        username = identity.username,
+                        uri = identity.uri,
+                        verifiedAt = identity.verifiedAt,
+                        providerId = identity.provider.id,
+                        providerName = identity.provider.name
+                    )
+                }
+            }
+        }
+
+        if (deviceName != null || location != null) {
+            attestationBuilder.addAssertionMetadata {
+                dateTime(getCurrentTimestamp())
+                deviceName?.let { device(it) }
+                location?.let { location(it) }
+            }
+        }
+
+        attestationBuilder.buildForManifest(builder)
+        return builder
+    }
+
+    fun createSocialMediaCreatorManifest(
+        title: String,
+        platform: String,
+        username: String,
+        verifiedAt: String = getCurrentTimestamp(),
+        format: String = C2PAFormats.JPEG,
+        claimGeneratorName: String = "Android C2PA SDK",
+        claimGeneratorVersion: String = "1.0.0"
+    ): ManifestBuilder {
+        val builder = ManifestBuilder()
+            .title(title)
+            .format(format)
+            .claimGenerator(claimGeneratorName, claimGeneratorVersion)
+            .addAction(Action(
+                action = C2PAActions.CREATED,
+                whenTimestamp = getCurrentTimestamp(),
+                softwareAgent = platform
+            ))
+
+        val attestationBuilder = AttestationBuilder()
+        attestationBuilder.addCAWGIdentity {
+            validFromNow()
+            when (platform.lowercase()) {
+                "instagram" -> addInstagramIdentity(username, verifiedAt)
+                "twitter", "x" -> addTwitterIdentity(username, verifiedAt)
+                "behance" -> addBehanceIdentity(username, verifiedAt)
+                "github" -> addGitHubIdentity(username, verifiedAt)
+                else -> addSocialMediaIdentity(
+                    username = username,
+                    uri = "https://$platform.com/$username",
+                    verifiedAt = verifiedAt,
+                    providerId = "https://$platform.com",
+                    providerName = platform.lowercase()
+                )
+            }
+        }
+
+        attestationBuilder.buildForManifest(builder)
+        return builder
+    }
+}

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/TestSuiteCore.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/TestSuiteCore.kt
@@ -1,6 +1,7 @@
 package org.contentauth.c2pa.test.shared
 
 import android.content.Context
+import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -15,11 +16,23 @@ import org.contentauth.c2pa.Reader
 import org.contentauth.c2pa.Signer
 import org.contentauth.c2pa.SignerInfo
 import org.contentauth.c2pa.SigningAlgorithm
+import org.contentauth.c2pa.manifest.Action
+import org.contentauth.c2pa.manifest.ActionsAttestation
+import org.contentauth.c2pa.manifest.AttestationBuilder
+import org.contentauth.c2pa.manifest.C2PAActions
+import org.contentauth.c2pa.manifest.C2PAAssertionTypes
+import org.contentauth.c2pa.manifest.C2PAFormats
+import org.contentauth.c2pa.manifest.ManifestHelpers
+import org.contentauth.c2pa.manifest.Thumbnail
 
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 /**
  * Shared test suite base class for C2PA functionality.
@@ -209,12 +222,9 @@ abstract class TestSuiteCore {
 
     suspend fun testBuilderAPI(): TestResult = withContext(Dispatchers.IO) {
         runTest("Builder API") {
-            val manifestJson = """{
-                "claim_generator": "test_app/1.0",
-                "assertions": [
-                    {"label": "c2pa.test", "data": {"test": true}}
-                ]
-            }"""
+
+            // Basic image manifest
+            val manifestJson = getTestManifest("pexels_asadphoto_457882.jpg")
 
             try {
                 val builder = Builder.fromJson(manifestJson)
@@ -394,12 +404,10 @@ abstract class TestSuiteCore {
 
         // Test 5: Builder API
         results.add(runTest("Builder API") {
-            val manifestJson = """{
-                "claim_generator": "test_app/1.0",
-                "assertions": [
-                    {"label": "c2pa.test", "data": {"test": true}}
-                ]
-            }"""
+
+            // Basic image manifest
+            val manifestJson = getTestManifest("pexels_asadphoto_457882.jpg")
+
 
             try {
                 val builder = Builder.fromJson(manifestJson)
@@ -446,10 +454,9 @@ abstract class TestSuiteCore {
 
         // Test 6: Builder No-Embed
         results.add(runTest("Builder No-Embed") {
-            val manifestJson = """{
-                "claim_generator": "test_app/1.0",
-                "assertions": [{"label": "c2pa.test", "data": {"test": true}}]
-            }"""
+
+            // Basic image manifest
+            val manifestJson = getTestManifestAdvanced("pexels_asadphoto_457882.jpg")
 
             try {
                 val builder = Builder.fromJson(manifestJson)
@@ -676,10 +683,7 @@ abstract class TestSuiteCore {
 
         // Test 10: Builder Remote URL
         results.add(runTest("Builder Remote URL") {
-            val manifestJson = """{
-                "claim_generator": "test_app/1.0",
-                "assertions": [{"label": "c2pa.test", "data": {"test": true}}]
-            }"""
+            val manifestJson = getTestManifest("pexels_asadphoto_457882.jpg")
 
             try {
                 val builder = Builder.fromJson(manifestJson)
@@ -711,10 +715,8 @@ abstract class TestSuiteCore {
 
         // Test 11: Builder Add Resource
         results.add(runTest("Builder Add Resource") {
-            val manifestJson = """{
-                "claim_generator": "test_app/1.0",
-                "assertions": [{"label": "c2pa.test", "data": {"test": true}}]
-            }"""
+
+            val manifestJson = getTestManifest("pexels_asadphoto_457882.jpg")
 
             try {
                 val builder = Builder.fromJson(manifestJson)
@@ -751,10 +753,8 @@ abstract class TestSuiteCore {
 
         // Test 12: Builder Add Ingredient
         results.add(runTest("Builder Add Ingredient") {
-            val manifestJson = """{
-                "claim_generator": "test_app/1.0",
-                "assertions": [{"label": "c2pa.test", "data": {"test": true}}]
-            }"""
+
+            val manifestJson = getTestManifest("pexels_asadphoto_457882.jpg")
 
             try {
                 val builder = Builder.fromJson(manifestJson)
@@ -792,10 +792,8 @@ abstract class TestSuiteCore {
 
         // Test 13: Builder from Archive
         results.add(runTest("Builder from Archive") {
-            val manifestJson = """{
-                "claim_generator": "test_app/1.0",
-                "assertions": [{"label": "c2pa.test", "data": {"test": true}}]
-            }"""
+
+            val manifestJson = getTestManifest("pexels_asadphoto_457882.jpg")
 
             try {
                 val originalBuilder = Builder.fromJson(manifestJson)
@@ -851,12 +849,7 @@ abstract class TestSuiteCore {
         // Test 14: Reader with Manifest Data
         results.add(runTest("Reader with Manifest Data") {
             try {
-                val manifestJson = """{
-                    "claim_generator": "test_app/1.0",
-                    "assertions": [
-                        {"label": "c2pa.test", "data": {"test": true}}
-                    ]
-                }"""
+                val manifestJson = getTestManifest("pexels_asadphoto_457882.jpg")
 
                 val builder = Builder.fromJson(manifestJson)
                 try {
@@ -914,10 +907,8 @@ abstract class TestSuiteCore {
 
         // Test 15: Signer with Callback
         results.add(runTest("Signer with Callback") {
-            val manifestJson = """{
-                "claim_generator": "test_app/1.0",
-                "assertions": [{"label": "c2pa.test", "data": {"test": true}}]
-            }"""
+
+            val manifestJson = getTestManifest("pexels_asadphoto_457882.jpg")
 
             try {
                 val builder = Builder.fromJson(manifestJson)
@@ -1032,10 +1023,8 @@ abstract class TestSuiteCore {
 
         // Test 17: Write-Only Streams
         results.add(runTest("Write-Only Streams") {
-            val manifestJson = """{
-                "claim_generator": "test_app/1.0",
-                "assertions": [{"label": "c2pa.test", "data": {"test": true}}]
-            }"""
+
+            val manifestJson = getTestManifest("pexels_asadphoto_457882.jpg")
 
             try {
                 val builder = Builder.fromJson(manifestJson)
@@ -1154,10 +1143,8 @@ abstract class TestSuiteCore {
 
         // Test 20: Web Service Signer Creation
         results.add(runTest("Web Service Real Signing & Verification") {
-            val manifestJson = """{
-                "claim_generator": "test_app/1.0",
-                "assertions": [{"label": "c2pa.test", "data": {"test": true}}]
-            }"""
+
+            val manifestJson = getTestManifest("pexels_asadphoto_457882.jpg")
 
             try {
                 val certPem = loadResourceAsString("es256_certs")
@@ -1544,10 +1531,7 @@ abstract class TestSuiteCore {
                 val keyPem = loadResourceAsString("es256_private")
                 val signerInfo = SignerInfo(SigningAlgorithm.ES256, certPem, keyPem)
 
-                val manifestJson = """{
-                    "claim_generator": "test_app/1.0",
-                    "assertions": [{"label": "c2pa.test", "data": {"test": true}}]
-                }"""
+                val manifestJson = getTestManifest("pexels_asadphoto_457882.jpg")
 
                 val result = C2PA.signFile(
                     sourceFile.absolutePath,
@@ -1577,6 +1561,7 @@ abstract class TestSuiteCore {
 
             try {
                 val reader = Reader.fromStream("image/jpeg", memStream.stream)
+
                 try {
                     val originalJson = reader.json()
                     val json1 = JSONObject(originalJson)
@@ -1780,4 +1765,87 @@ abstract class TestSuiteCore {
             0xFF.toByte(), 0xD9.toByte()
         )
     }
+
+    private fun getTestManifest(title: String): String {
+        // Basic image manifest
+        val manifestJson = ManifestHelpers.createBasicImageManifest(
+            title = title,
+            format = C2PAFormats.JPEG
+        ).claimGenerator("Android Test Suite","1.0.0")
+            .addAction(Action(C2PAActions.OPENED, whenTimestamp = getCurrentTimestamp(),"Android Test Suite"))
+            .addAssertion("c2pa.test","{\"test\": true}")
+            .buildJson()
+
+        return manifestJson
+    }
+
+    private fun getTestManifestAdvanced(title: String): String {
+
+        // Basic image manifest
+        val manifestBuilder = ManifestHelpers.createBasicImageManifest(
+            title = title,
+            format = C2PAFormats.JPEG
+        ).claimGenerator("Android Test Suite","1.0.0")
+            .addAction(Action(C2PAActions.PLACED, whenTimestamp = getCurrentTimestamp(),"Android Test Suite"))
+            .addAssertion("c2pa.test","{\"test\": true}")
+            .addThumbnail(Thumbnail(C2PAFormats.JPEG,"${title}_thumb.jpg"))
+
+        val attestationBuilder = AttestationBuilder()
+
+        attestationBuilder.addCreativeWork {
+            addAuthor("Test Author")
+            dateCreated(Date())
+        }
+
+        attestationBuilder.addCreativeWork {
+            addAuthor("Test Author")
+            dateCreated(Date())
+        }
+
+        val locationJson = JSONObject().apply {
+            put("@type", "Place")
+            put("latitude", "0.0")
+            put("longitude", "0.0")
+            put("name", "Somewhere")
+        }
+
+        attestationBuilder.addAssertionMetadata {
+            dateTime(getCurrentTimestamp())
+            device("Test Device")
+            location(locationJson)
+        }
+
+        val customAttestationJson = JSONObject().apply {
+            put("@type", "Integrity")
+            put("nonce", "something")
+            put("response", "b64encodedresponse")
+        }
+
+        attestationBuilder.addCustomAttestation("app.integrity", customAttestationJson)
+
+        attestationBuilder.addCAWGIdentity {
+            validFromNow()
+            addInstagramIdentity("photographer_john", "2024-10-08T18:04:08Z")
+            addLinkedInIdentity("John Smith", "https://www.linkedin.com/in/jsmith", "2024-10-08T18:03:41Z")
+            addBehanceIdentity("johnsmith_photos", "2024-10-22T19:31:17Z")
+        }
+
+        attestationBuilder.buildForManifest(manifestBuilder)
+
+        manifestBuilder.addAction(Action(C2PAActions.RECOMPRESSED, getCurrentTimestamp(), "Photo Resizer"))
+
+        val resultJson = manifestBuilder.buildJson()
+
+        Log.d("Test Manifest",resultJson)
+
+        return resultJson
+    }
+
+    private fun getCurrentTimestamp(): String {
+        val iso8601 = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+        return iso8601.format(Date())
+    }
+
 }


### PR DESCRIPTION

## Changes in this pull request
- added new org/contentauth/c2pa/manifest package, with ManifestBuilder and other utility classes
- updated test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/TestSuiteCore.kt with example usage code

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
-