### PR TITLE
feat: Add iOS-equivalent manifest-building features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Gradle
 .gradle/
+.kotlin/
 build/
 */build/
 downloads/

--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidManifestTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidManifestTests.kt
@@ -1,0 +1,154 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+package org.contentauth.c2pa
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.contentauth.c2pa.test.shared.ManifestTests
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import kotlin.test.assertTrue
+
+/** Android instrumented tests for Manifest definition types. */
+@RunWith(AndroidJUnit4::class)
+class AndroidManifestTests : ManifestTests() {
+
+    private val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+    override fun getContext(): Context = targetContext
+
+    override fun loadResourceAsBytes(resourceName: String): ByteArray =
+        ResourceTestHelper.loadResourceAsBytes(resourceName)
+
+    override fun loadResourceAsString(resourceName: String): String =
+        ResourceTestHelper.loadResourceAsString(resourceName)
+
+    override fun copyResourceToFile(resourceName: String, fileName: String): File =
+        ResourceTestHelper.copyResourceToFile(targetContext, resourceName, fileName)
+
+    @Test
+    fun runTestMinimal() = runBlocking {
+        val result = testMinimal()
+        assertTrue(result.success, "Manifest Minimal test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestCreated() = runBlocking {
+        val result = testCreated()
+        assertTrue(result.success, "Manifest Created test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestEnumRendering() = runBlocking {
+        val result = testEnumRendering()
+        assertTrue(result.success, "Enum Rendering test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestRegionOfInterest() = runBlocking {
+        val result = testRegionOfInterest()
+        assertTrue(result.success, "Region of Interest test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestResourceRef() = runBlocking {
+        val result = testResourceRef()
+        assertTrue(result.success, "ResourceRef test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestHashedUri() = runBlocking {
+        val result = testHashedUri()
+        assertTrue(result.success, "HashedUri test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestUriOrResource() = runBlocking {
+        val result = testUriOrResource()
+        assertTrue(result.success, "UriOrResource test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestMassInit() = runBlocking {
+        val result = testMassInit()
+        assertTrue(result.success, "Mass Init test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestManifestToJson() = runBlocking {
+        val result = testManifestToJson()
+        assertTrue(result.success, "Manifest to JSON test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestShapeFactoryMethods() = runBlocking {
+        val result = testShapeFactoryMethods()
+        assertTrue(result.success, "Shape Factory Methods test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestManifestWithBuilder() = runBlocking {
+        val result = testManifestWithBuilder()
+        assertTrue(result.success, "Manifest with Builder test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestAllAssertionTypes() = runBlocking {
+        val result = testAllAssertionTypes()
+        assertTrue(result.success, "All Assertion Types test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestIngredients() = runBlocking {
+        val result = testIngredients()
+        assertTrue(result.success, "Ingredients test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestActionWithRegions() = runBlocking {
+        val result = testActionWithRegions()
+        assertTrue(result.success, "Action with Regions test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestMalformedJson() = runBlocking {
+        val result = testMalformedJson()
+        assertTrue(result.success, "Malformed JSON test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestSpecialCharacters() = runBlocking {
+        val result = testSpecialCharacters()
+        assertTrue(result.success, "Special Characters test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestCreatedFactory() = runBlocking {
+        val result = testCreatedFactory()
+        assertTrue(result.success, "Created Factory test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestAllValidationStatusCodes() = runBlocking {
+        val result = testAllValidationStatusCodes()
+        assertTrue(result.success, "All Validation Status Codes test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestAllDigitalSourceTypes() = runBlocking {
+        val result = testAllDigitalSourceTypes()
+        assertTrue(result.success, "All Digital Source Types test failed: ${result.message}")
+    }
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ActionAssertion.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ActionAssertion.kt
@@ -1,0 +1,119 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.contentauth.c2pa.DigitalSourceType
+import org.contentauth.c2pa.PredefinedAction
+
+/**
+ * Represents an action performed on the asset for use in manifest assertions.
+ *
+ * This is the serializable version of Action for use within AssertionDefinition.
+ *
+ * @property action The action name (use [PredefinedAction.value] or a custom action string).
+ * @property digitalSourceType A URL identifying an IPTC digital source type.
+ * @property softwareAgent The software or hardware used to perform the action.
+ * @property parameters Additional information describing the action.
+ * @property when The timestamp when the action was performed (ISO 8601 format).
+ * @property changes Regions of interest describing what changed.
+ * @property related Related ingredient labels.
+ * @property reason The reason for performing the action.
+ * @see AssertionDefinition
+ * @see PredefinedAction
+ */
+@Serializable
+data class ActionAssertion(
+    val action: String,
+    val digitalSourceType: String? = null,
+    val softwareAgent: String? = null,
+    val parameters: Map<String, String>? = null,
+    @SerialName("when")
+    val whenPerformed: String? = null,
+    val changes: List<RegionOfInterest>? = null,
+    val related: List<String>? = null,
+    val reason: String? = null,
+) {
+    /**
+     * Creates an action using a [PredefinedAction] and [DigitalSourceType].
+     */
+    constructor(
+        action: PredefinedAction,
+        digitalSourceType: DigitalSourceType? = null,
+        softwareAgent: String? = null,
+        parameters: Map<String, String>? = null,
+        whenPerformed: String? = null,
+        changes: List<RegionOfInterest>? = null,
+        related: List<String>? = null,
+        reason: String? = null,
+    ) : this(
+        action = action.value,
+        digitalSourceType = digitalSourceType?.toIptcUrl(),
+        softwareAgent = softwareAgent,
+        parameters = parameters,
+        whenPerformed = whenPerformed,
+        changes = changes,
+        related = related,
+        reason = reason,
+    )
+
+    companion object {
+        /**
+         * Creates a "created" action with the specified digital source type.
+         */
+        fun created(
+            digitalSourceType: DigitalSourceType,
+            softwareAgent: String? = null,
+        ) = ActionAssertion(
+            action = PredefinedAction.CREATED,
+            digitalSourceType = digitalSourceType,
+            softwareAgent = softwareAgent,
+        )
+
+        /**
+         * Creates an "edited" action.
+         */
+        fun edited(
+            softwareAgent: String? = null,
+            changes: List<RegionOfInterest>? = null,
+        ) = ActionAssertion(
+            action = PredefinedAction.EDITED,
+            softwareAgent = softwareAgent,
+            changes = changes,
+        )
+    }
+}
+
+private fun DigitalSourceType.toIptcUrl(): String =
+    when (this) {
+        DigitalSourceType.EMPTY -> "http://c2pa.org/digitalsourcetype/empty"
+        DigitalSourceType.TRAINED_ALGORITHMIC_DATA -> "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicData"
+        DigitalSourceType.DIGITAL_CAPTURE -> "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCapture"
+        DigitalSourceType.COMPUTATIONAL_CAPTURE -> "http://cv.iptc.org/newscodes/digitalsourcetype/computationalCapture"
+        DigitalSourceType.NEGATIVE_FILM -> "http://cv.iptc.org/newscodes/digitalsourcetype/negativeFilm"
+        DigitalSourceType.POSITIVE_FILM -> "http://cv.iptc.org/newscodes/digitalsourcetype/positiveFilm"
+        DigitalSourceType.PRINT -> "http://cv.iptc.org/newscodes/digitalsourcetype/print"
+        DigitalSourceType.HUMAN_EDITS -> "http://cv.iptc.org/newscodes/digitalsourcetype/humanEdits"
+        DigitalSourceType.COMPOSITE_WITH_TRAINED_ALGORITHMIC_MEDIA -> "http://cv.iptc.org/newscodes/digitalsourcetype/compositeWithTrainedAlgorithmicMedia"
+        DigitalSourceType.ALGORITHMICALLY_ENHANCED -> "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicallyEnhanced"
+        DigitalSourceType.DIGITAL_CREATION -> "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCreation"
+        DigitalSourceType.DATA_DRIVEN_MEDIA -> "http://cv.iptc.org/newscodes/digitalsourcetype/dataDrivenMedia"
+        DigitalSourceType.TRAINED_ALGORITHMIC_MEDIA -> "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+        DigitalSourceType.ALGORITHMIC_MEDIA -> "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
+        DigitalSourceType.SCREEN_CAPTURE -> "http://cv.iptc.org/newscodes/digitalsourcetype/screenCapture"
+        DigitalSourceType.VIRTUAL_RECORDING -> "http://cv.iptc.org/newscodes/digitalsourcetype/virtualRecording"
+        DigitalSourceType.COMPOSITE -> "http://cv.iptc.org/newscodes/digitalsourcetype/composite"
+        DigitalSourceType.COMPOSITE_CAPTURE -> "http://cv.iptc.org/newscodes/digitalsourcetype/compositeCapture"
+        DigitalSourceType.COMPOSITE_SYNTHETIC -> "http://cv.iptc.org/newscodes/digitalsourcetype/compositeSynthetic"
+    }

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/AssertionDefinition.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/AssertionDefinition.kt
@@ -1,0 +1,264 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * Represents a C2PA assertion within a manifest.
+ *
+ * Assertions are statements about the asset, such as actions performed,
+ * metadata, or cryptographic bindings.
+ *
+ * @see ManifestDefinition
+ * @see StandardAssertionLabel
+ */
+@Serializable(with = AssertionDefinitionSerializer::class)
+sealed class AssertionDefinition {
+    /**
+     * An actions assertion containing a list of actions performed on the asset.
+     *
+     * @property actions The list of actions performed.
+     * @property metadata Optional metadata about the actions.
+     */
+    data class Actions(
+        val actions: List<ActionAssertion>,
+        val metadata: Metadata? = null,
+    ) : AssertionDefinition()
+
+    /**
+     * A creative work assertion containing Schema.org CreativeWork metadata.
+     *
+     * @property data The creative work data as key-value pairs.
+     */
+    data class CreativeWork(
+        val data: Map<String, JsonElement>,
+    ) : AssertionDefinition()
+
+    /**
+     * An EXIF metadata assertion.
+     *
+     * @property data The EXIF data as key-value pairs.
+     */
+    data class Exif(
+        val data: Map<String, JsonElement>,
+    ) : AssertionDefinition()
+
+    /**
+     * An IPTC photo metadata assertion.
+     *
+     * @property data The IPTC photo metadata as key-value pairs.
+     */
+    data class IptcPhotoMetadata(
+        val data: Map<String, JsonElement>,
+    ) : AssertionDefinition()
+
+    /**
+     * A training/mining assertion specifying AI training permissions.
+     *
+     * @property entries The training/mining permission entries.
+     */
+    data class TrainingMining(
+        val entries: List<TrainingMiningEntry>,
+    ) : AssertionDefinition()
+
+    /**
+     * A custom assertion with an arbitrary label and data.
+     *
+     * @property label The assertion label.
+     * @property data The assertion data.
+     */
+    data class Custom(
+        val label: String,
+        val data: JsonElement,
+    ) : AssertionDefinition()
+
+    companion object {
+        /**
+         * Creates an actions assertion with the specified actions.
+         */
+        fun actions(
+            actions: List<ActionAssertion>,
+            metadata: Metadata? = null,
+        ) = Actions(actions, metadata)
+
+        /**
+         * Creates a single action assertion.
+         */
+        fun action(action: ActionAssertion) = Actions(listOf(action))
+
+        /**
+         * Creates a creative work assertion.
+         */
+        fun creativeWork(data: Map<String, JsonElement>) = CreativeWork(data)
+
+        /**
+         * Creates an EXIF assertion.
+         */
+        fun exif(data: Map<String, JsonElement>) = Exif(data)
+
+        /**
+         * Creates a training/mining assertion.
+         */
+        fun trainingMining(entries: List<TrainingMiningEntry>) = TrainingMining(entries)
+
+        /**
+         * Creates a custom assertion.
+         */
+        fun custom(label: String, data: JsonElement) = Custom(label, data)
+    }
+}
+
+/**
+ * Represents a training/mining permission entry.
+ *
+ * @property use The type of use (e.g., "allowed", "notAllowed", "constrained").
+ * @property constraint Optional constraint URL or description.
+ */
+@Serializable
+data class TrainingMiningEntry(
+    val use: String,
+    @SerialName("constraint_info")
+    val constraintInfo: String? = null,
+)
+
+/**
+ * Custom serializer for AssertionDefinition that handles the label/data structure.
+ */
+internal object AssertionDefinitionSerializer : KSerializer<AssertionDefinition> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("AssertionDefinition")
+
+    @OptIn(ExperimentalSerializationApi::class)
+    override fun serialize(encoder: Encoder, value: AssertionDefinition) {
+        val jsonEncoder = encoder as? JsonEncoder
+            ?: throw IllegalStateException("AssertionDefinition can only be serialized as JSON")
+
+        val jsonObject = when (value) {
+            is AssertionDefinition.Actions -> buildJsonObject {
+                put("label", StandardAssertionLabel.ACTIONS.serialName())
+                put("data", buildJsonObject {
+                    put("actions", jsonEncoder.json.encodeToJsonElement(value.actions))
+                    value.metadata?.let { put("metadata", jsonEncoder.json.encodeToJsonElement(it)) }
+                })
+            }
+            is AssertionDefinition.CreativeWork -> buildJsonObject {
+                put("label", StandardAssertionLabel.CREATIVE_WORK.serialName())
+                put("data", JsonObject(value.data))
+            }
+            is AssertionDefinition.Exif -> buildJsonObject {
+                put("label", StandardAssertionLabel.EXIF.serialName())
+                put("data", JsonObject(value.data))
+            }
+            is AssertionDefinition.IptcPhotoMetadata -> buildJsonObject {
+                put("label", StandardAssertionLabel.IPTC_PHOTO_METADATA.serialName())
+                put("data", JsonObject(value.data))
+            }
+            is AssertionDefinition.TrainingMining -> buildJsonObject {
+                put("label", StandardAssertionLabel.TRAINING_MINING.serialName())
+                put("data", buildJsonObject {
+                    put("entries", jsonEncoder.json.encodeToJsonElement(value.entries))
+                })
+            }
+            is AssertionDefinition.Custom -> buildJsonObject {
+                put("label", value.label)
+                put("data", value.data)
+            }
+        }
+        jsonEncoder.encodeJsonElement(jsonObject)
+    }
+
+    override fun deserialize(decoder: Decoder): AssertionDefinition {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw IllegalStateException("AssertionDefinition can only be deserialized from JSON")
+
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        val label = jsonObject["label"]?.jsonPrimitive?.content
+            ?: throw IllegalStateException("Missing label in assertion")
+        val data = jsonObject["data"]?.jsonObject
+            ?: throw IllegalStateException("Missing data in assertion")
+
+        return when (label) {
+            StandardAssertionLabel.ACTIONS.serialName(),
+            StandardAssertionLabel.ACTIONS_V2.serialName() -> {
+                val actions = data["actions"]?.let {
+                    jsonDecoder.json.decodeFromJsonElement(
+                        kotlinx.serialization.builtins.ListSerializer(ActionAssertion.serializer()),
+                        it,
+                    )
+                } ?: emptyList()
+                val metadata = data["metadata"]?.let {
+                    jsonDecoder.json.decodeFromJsonElement(Metadata.serializer(), it)
+                }
+                AssertionDefinition.Actions(actions, metadata)
+            }
+            StandardAssertionLabel.CREATIVE_WORK.serialName() -> {
+                AssertionDefinition.CreativeWork(data.toMap())
+            }
+            StandardAssertionLabel.EXIF.serialName() -> {
+                AssertionDefinition.Exif(data.toMap())
+            }
+            StandardAssertionLabel.IPTC_PHOTO_METADATA.serialName() -> {
+                AssertionDefinition.IptcPhotoMetadata(data.toMap())
+            }
+            StandardAssertionLabel.TRAINING_MINING.serialName() -> {
+                val entries = data["entries"]?.let {
+                    jsonDecoder.json.decodeFromJsonElement(
+                        kotlinx.serialization.builtins.ListSerializer(TrainingMiningEntry.serializer()),
+                        it,
+                    )
+                } ?: emptyList()
+                AssertionDefinition.TrainingMining(entries)
+            }
+            else -> {
+                AssertionDefinition.Custom(label, JsonObject(data))
+            }
+        }
+    }
+}
+
+private fun StandardAssertionLabel.serialName(): String = when (this) {
+    StandardAssertionLabel.ACTIONS -> "c2pa.actions"
+    StandardAssertionLabel.ACTIONS_V2 -> "c2pa.actions.v2"
+    StandardAssertionLabel.HASH_DATA -> "c2pa.hash.data"
+    StandardAssertionLabel.HASH_BOXES -> "c2pa.hash.boxes"
+    StandardAssertionLabel.HASH_BMFF_V2 -> "c2pa.hash.bmff.v2"
+    StandardAssertionLabel.HASH_COLLECTION -> "c2pa.hash.collection"
+    StandardAssertionLabel.SOFT_BINDING -> "c2pa.soft-binding"
+    StandardAssertionLabel.CLOUD_DATA -> "c2pa.cloud-data"
+    StandardAssertionLabel.THUMBNAIL_CLAIM -> "c2pa.thumbnail.claim"
+    StandardAssertionLabel.THUMBNAIL_INGREDIENT -> "c2pa.thumbnail.ingredient"
+    StandardAssertionLabel.DEPTHMAP -> "c2pa.depthmap"
+    StandardAssertionLabel.TRAINING_MINING -> "c2pa.training-mining"
+    StandardAssertionLabel.EXIF -> "stds.exif"
+    StandardAssertionLabel.CREATIVE_WORK -> "stds.schema-org.CreativeWork"
+    StandardAssertionLabel.IPTC_PHOTO_METADATA -> "stds.iptc.photo-metadata"
+    StandardAssertionLabel.ISO_LOCATION -> "stds.iso.location.v1"
+    StandardAssertionLabel.CAWG_IDENTITY -> "cawg.identity"
+    StandardAssertionLabel.CAWG_AI_TRAINING -> "cawg.ai_training_and_data_mining"
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/AssetType.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/AssetType.kt
@@ -1,0 +1,29 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Describes the type and version of an asset.
+ *
+ * @property type The asset type identifier or MIME type.
+ * @property version The optional version of the asset type.
+ * @see ResourceRef
+ * @see Ingredient
+ */
+@Serializable
+data class AssetType(
+    val type: String,
+    val version: String? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ClaimGeneratorInfo.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ClaimGeneratorInfo.kt
@@ -1,0 +1,85 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Information about the software that created the manifest claim.
+ *
+ * @property name The name of the software or tool.
+ * @property version The version of the software.
+ * @property operatingSystem The operating system the software is running on.
+ * @property icon An optional icon for the software.
+ * @see ManifestDefinition
+ */
+@Serializable
+data class ClaimGeneratorInfo(
+    val name: String,
+    val version: String? = null,
+    @SerialName("operating_system")
+    val operatingSystem: String? = null,
+    val icon: UriOrResource? = null,
+) {
+    companion object {
+        /**
+         * Creates a ClaimGeneratorInfo using the current app's information.
+         *
+         * @param context The Android context to get app info from.
+         * @param name Optional override for the app name.
+         * @return ClaimGeneratorInfo populated with app details.
+         */
+        fun fromContext(
+            context: Context,
+            name: String? = null,
+        ): ClaimGeneratorInfo {
+            val packageInfo = try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    context.packageManager.getPackageInfo(
+                        context.packageName,
+                        PackageManager.PackageInfoFlags.of(0),
+                    )
+                } else {
+                    @Suppress("DEPRECATION")
+                    context.packageManager.getPackageInfo(context.packageName, 0)
+                }
+            } catch (e: PackageManager.NameNotFoundException) {
+                null
+            }
+
+            val appName = name ?: try {
+                context.applicationInfo.loadLabel(context.packageManager).toString()
+            } catch (e: Exception) {
+                context.packageName
+            }
+
+            val appVersion = packageInfo?.versionName
+
+            return ClaimGeneratorInfo(
+                name = appName,
+                version = appVersion,
+                operatingSystem = operatingSystem,
+            )
+        }
+
+        /**
+         * The operating system string for the current device.
+         */
+        val operatingSystem: String
+            get() = "Android ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})"
+    }
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/Coordinate.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/Coordinate.kt
@@ -1,0 +1,28 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a 2D coordinate point.
+ *
+ * @property x The x-coordinate value.
+ * @property y The y-coordinate value.
+ * @see Shape
+ */
+@Serializable
+data class Coordinate(
+    val x: Double,
+    val y: Double,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/DataSource.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/DataSource.kt
@@ -1,0 +1,30 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Describes the source of assertion data.
+ *
+ * @property type The type of data source.
+ * @property details Additional details about the data source.
+ * @property actors The actors (people or entities) associated with this data source.
+ * @see Metadata
+ */
+@Serializable
+data class DataSource(
+    val type: String? = null,
+    val details: String? = null,
+    val actors: List<MetadataActor>? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/Frame.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/Frame.kt
@@ -1,0 +1,28 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a frame range for video or animation content.
+ *
+ * @property start The starting frame number (inclusive).
+ * @property end The ending frame number (inclusive).
+ * @see RegionRange
+ */
+@Serializable
+data class Frame(
+    val start: Int? = null,
+    val end: Int? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/HashedUri.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/HashedUri.kt
@@ -1,0 +1,30 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A URI reference with an associated hash for integrity verification.
+ *
+ * @property url The URL being referenced.
+ * @property hash The hash bytes for integrity verification (base64 encoded).
+ * @property alg The algorithm used for hashing.
+ * @see MetadataActor
+ */
+@Serializable
+data class HashedUri(
+    val url: String? = null,
+    val hash: String? = null,
+    val alg: String? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ImageRegionType.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ImageRegionType.kt
@@ -1,0 +1,90 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * IPTC Image Region types for categorizing regions of interest.
+ *
+ * These types describe what kind of subject or content is within a region.
+ *
+ * @see RegionOfInterest
+ */
+@Serializable
+enum class ImageRegionType {
+    /** A human subject. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/human")
+    HUMAN,
+
+    /** A face within the region. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/face")
+    FACE,
+
+    /** A headshot of a person. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/headshot")
+    HEADSHOT,
+
+    /** A body part. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/bodyPart")
+    BODY_PART,
+
+    /** An animal subject. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/animal")
+    ANIMAL,
+
+    /** A plant subject. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/plant")
+    PLANT,
+
+    /** A product or item. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/product")
+    PRODUCT,
+
+    /** A building or structure. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/building")
+    BUILDING,
+
+    /** An object. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/object")
+    OBJECT,
+
+    /** A vehicle. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/vehicle")
+    VEHICLE,
+
+    /** An event. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/event")
+    EVENT,
+
+    /** An artwork. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/artwork")
+    ARTWORK,
+
+    /** A logo. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/logo")
+    LOGO,
+
+    /** Text content. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/text")
+    TEXT,
+
+    /** A visible code (QR, barcode, etc.). */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/visibleCode")
+    VISIBLE_CODE,
+
+    /** A geographical feature or landmark. */
+    @SerialName("http://cv.iptc.org/newscodes/imageregiontype/geoFeature")
+    GEO_FEATURE,
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/Ingredient.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/Ingredient.kt
@@ -1,0 +1,105 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an ingredient in a manifest - an external asset that was used in creating the content.
+ *
+ * Ingredients document the provenance chain by referencing parent assets, components,
+ * or other inputs that contributed to the creation of the current asset.
+ *
+ * @property title The title or name of the ingredient.
+ * @property format The MIME type of the ingredient (e.g., "image/jpeg").
+ * @property relationship The relationship of this ingredient to the manifest.
+ * @property data Reference to the ingredient's data.
+ * @property thumbnail Reference to a thumbnail of the ingredient.
+ * @property manifestData Reference to the ingredient's manifest data.
+ * @property activeManifest The label of the active manifest in the ingredient.
+ * @property hash The hash of the ingredient data.
+ * @property description A human-readable description of the ingredient.
+ * @property label A unique label for this ingredient.
+ * @property dataTypes The data types associated with this ingredient.
+ * @property validationStatus The validation status codes for this ingredient.
+ * @property validationResults Detailed validation results for this ingredient.
+ * @property metadata Additional metadata about the ingredient.
+ * @property documentId A document identifier for the ingredient.
+ * @property instanceId An instance identifier for the ingredient.
+ * @property provenance A URL to the ingredient's provenance information.
+ * @property informationalUri A URL with additional information about the ingredient.
+ * @see ManifestDefinition
+ * @see Relationship
+ */
+@Serializable
+data class Ingredient(
+    val title: String? = null,
+    val format: String? = null,
+    val relationship: Relationship? = null,
+    val data: ResourceRef? = null,
+    val thumbnail: ResourceRef? = null,
+    @SerialName("manifest_data")
+    val manifestData: ResourceRef? = null,
+    @SerialName("active_manifest")
+    val activeManifest: String? = null,
+    val hash: String? = null,
+    val description: String? = null,
+    val label: String? = null,
+    @SerialName("data_types")
+    val dataTypes: List<AssetType>? = null,
+    @SerialName("validation_status")
+    val validationStatus: List<ValidationStatus>? = null,
+    @SerialName("validation_results")
+    val validationResults: ValidationResults? = null,
+    val metadata: Metadata? = null,
+    @SerialName("document_id")
+    val documentId: String? = null,
+    @SerialName("instance_id")
+    val instanceId: String? = null,
+    val provenance: String? = null,
+    @SerialName("informational_uri")
+    val informationalUri: String? = null,
+) {
+    companion object {
+        /**
+         * Creates a parent ingredient with the specified title.
+         *
+         * @param title The title of the parent ingredient.
+         * @param format The MIME type of the ingredient.
+         */
+        fun parent(
+            title: String,
+            format: String? = null,
+        ) = Ingredient(
+            title = title,
+            format = format,
+            relationship = Relationship.PARENT_OF,
+        )
+
+        /**
+         * Creates a component ingredient with the specified title.
+         *
+         * @param title The title of the component ingredient.
+         * @param format The MIME type of the ingredient.
+         */
+        fun component(
+            title: String,
+            format: String? = null,
+        ) = Ingredient(
+            title = title,
+            format = format,
+            relationship = Relationship.COMPONENT_OF,
+        )
+    }
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/IngredientDeltaValidationResult.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/IngredientDeltaValidationResult.kt
@@ -1,0 +1,31 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Validation results for an ingredient delta.
+ *
+ * @property ingredientAssertionUri The URI of the ingredient assertion being validated.
+ * @property validationDeltas The validation status codes for this ingredient delta.
+ * @see ValidationResults
+ */
+@Serializable
+data class IngredientDeltaValidationResult(
+    @SerialName("ingredient_assertion_uri")
+    val ingredientAssertionUri: String,
+    @SerialName("validation_deltas")
+    val validationDeltas: StatusCodes,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/Item.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/Item.kt
@@ -1,0 +1,30 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an identified item within a container.
+ *
+ * Used for identifying specific elements within structured content.
+ *
+ * @property identifier The identifier scheme or type.
+ * @property value The identifier value.
+ * @see RegionRange
+ */
+@Serializable
+data class Item(
+    val identifier: String,
+    val value: String,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ManifestDefinition.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ManifestDefinition.kt
@@ -1,0 +1,133 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Defines a C2PA manifest for content authenticity.
+ *
+ * ManifestDefinition is the root type for building C2PA manifests. It contains all the
+ * information needed to create a signed manifest, including claims, assertions, and ingredients.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val manifest = ManifestDefinition(
+ *     title = "My Photo",
+ *     claimGeneratorInfo = listOf(ClaimGeneratorInfo.fromContext(context)),
+ *     assertions = listOf(
+ *         AssertionDefinition.actions(listOf(
+ *             ActionAssertion.created(DigitalSourceType.DIGITAL_CAPTURE)
+ *         ))
+ *     )
+ * )
+ *
+ * // Convert to JSON for use with Builder
+ * val json = manifest.toJson()
+ * val builder = Builder.fromJson(json)
+ * ```
+ *
+ * @property title The title of the asset.
+ * @property claimGeneratorInfo Information about the software creating the claim.
+ * @property assertions The list of assertions in this manifest.
+ * @property ingredients The list of ingredients (parent assets) used in this manifest.
+ * @property thumbnail Reference to a thumbnail image for this asset.
+ * @property format The MIME type of the asset (e.g., "image/jpeg").
+ * @property vendor An optional vendor identifier.
+ * @property label An optional unique label for this manifest.
+ * @property instanceId An optional instance identifier.
+ * @property redactions A list of assertion URIs to redact from ingredients.
+ * @see AssertionDefinition
+ * @see Ingredient
+ * @see ClaimGeneratorInfo
+ */
+@Serializable
+data class ManifestDefinition(
+    val title: String,
+    @SerialName("claim_generator_info")
+    val claimGeneratorInfo: List<ClaimGeneratorInfo>,
+    val assertions: List<AssertionDefinition> = emptyList(),
+    val ingredients: List<Ingredient> = emptyList(),
+    val thumbnail: ResourceRef? = null,
+    val format: String? = null,
+    val vendor: String? = null,
+    val label: String? = null,
+    @SerialName("instance_id")
+    val instanceId: String? = null,
+    val redactions: List<String>? = null,
+) {
+    /**
+     * Converts this manifest definition to a JSON string.
+     *
+     * The resulting JSON can be used with [org.contentauth.c2pa.Builder.fromJson].
+     *
+     * @return The manifest as a JSON string.
+     */
+    fun toJson(): String = json.encodeToString(this)
+
+    /**
+     * Converts this manifest definition to a pretty-printed JSON string.
+     *
+     * @return The manifest as a formatted JSON string.
+     */
+    fun toPrettyJson(): String = prettyJson.encodeToString(this)
+
+    override fun toString(): String = toJson()
+
+    companion object {
+        private val json = Json {
+            encodeDefaults = false
+            ignoreUnknownKeys = true
+        }
+
+        private val prettyJson = Json {
+            encodeDefaults = false
+            ignoreUnknownKeys = true
+            prettyPrint = true
+        }
+
+        /**
+         * Parses a ManifestDefinition from a JSON string.
+         *
+         * @param jsonString The JSON string to parse.
+         * @return The parsed ManifestDefinition.
+         */
+        fun fromJson(jsonString: String): ManifestDefinition =
+            json.decodeFromString(jsonString)
+
+        /**
+         * Creates a minimal manifest definition for a newly created asset.
+         *
+         * @param title The title of the asset.
+         * @param claimGeneratorInfo The claim generator info.
+         * @param digitalSourceType The digital source type for the created action.
+         */
+        fun created(
+            title: String,
+            claimGeneratorInfo: ClaimGeneratorInfo,
+            digitalSourceType: org.contentauth.c2pa.DigitalSourceType,
+        ) = ManifestDefinition(
+            title = title,
+            claimGeneratorInfo = listOf(claimGeneratorInfo),
+            assertions = listOf(
+                AssertionDefinition.action(
+                    ActionAssertion.created(digitalSourceType),
+                ),
+            ),
+        )
+    }
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/Metadata.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/Metadata.kt
@@ -1,0 +1,40 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Container for assertion metadata.
+ *
+ * @property dataSource The source of the data in this assertion.
+ * @property reference A reference identifier for this metadata.
+ * @property regionOfInterest Regions of interest associated with this metadata.
+ * @property reviewRatings Review ratings for this assertion.
+ * @property dateTime The date/time associated with this metadata (ISO 8601 format).
+ * @see RegionOfInterest
+ * @see DataSource
+ */
+@Serializable
+data class Metadata(
+    @SerialName("dataSource")
+    val dataSource: DataSource? = null,
+    val reference: String? = null,
+    @SerialName("regionOfInterest")
+    val regionOfInterest: List<RegionOfInterest>? = null,
+    @SerialName("reviewRatings")
+    val reviewRatings: List<ReviewRating>? = null,
+    @SerialName("dateTime")
+    val dateTime: String? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/MetadataActor.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/MetadataActor.kt
@@ -1,0 +1,28 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an actor (person or entity) associated with metadata.
+ *
+ * @property identifier A unique identifier for the actor.
+ * @property credentials A list of credential references for the actor.
+ * @see DataSource
+ */
+@Serializable
+data class MetadataActor(
+    val identifier: String? = null,
+    val credentials: List<HashedUri>? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/RangeType.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/RangeType.kt
@@ -1,0 +1,44 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Defines the type of range for a region.
+ *
+ * @see RegionRange
+ */
+@Serializable
+enum class RangeType {
+    /** A spatial region defined by geometric shapes. */
+    @SerialName("spatial")
+    SPATIAL,
+
+    /** A temporal region defined by time values. */
+    @SerialName("temporal")
+    TEMPORAL,
+
+    /** A frame-based region defined by frame numbers. */
+    @SerialName("frame")
+    FRAME,
+
+    /** A textual region defined by text selectors. */
+    @SerialName("textual")
+    TEXTUAL,
+
+    /** An identified region within a container. */
+    @SerialName("identified")
+    IDENTIFIED,
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/RegionOfInterest.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/RegionOfInterest.kt
@@ -1,0 +1,121 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a region of interest within an asset.
+ *
+ * Regions of interest can identify specific areas of content that have been
+ * modified, contain specific subjects, or are otherwise notable.
+ *
+ * @property region The list of ranges defining this region.
+ * @property description A human-readable description of the region.
+ * @property name A name for the region.
+ * @property identifier A unique identifier for the region.
+ * @property role The role of this region (what action was performed).
+ * @property type The IPTC type of content in this region.
+ * @property metadata Additional metadata about the region.
+ * @see RegionRange
+ * @see Role
+ * @see ImageRegionType
+ */
+@Serializable
+data class RegionOfInterest(
+    val region: List<RegionRange>,
+    val description: String? = null,
+    val name: String? = null,
+    val identifier: String? = null,
+    val role: Role? = null,
+    @SerialName("type")
+    val regionType: String? = null,
+    val metadata: Metadata? = null,
+) {
+    /**
+     * Creates a region of interest with an IPTC image region type.
+     */
+    constructor(
+        region: List<RegionRange>,
+        description: String? = null,
+        name: String? = null,
+        identifier: String? = null,
+        role: Role? = null,
+        imageRegionType: ImageRegionType,
+        metadata: Metadata? = null,
+    ) : this(
+        region = region,
+        description = description,
+        name = name,
+        identifier = identifier,
+        role = role,
+        regionType = imageRegionType.toTypeString(),
+        metadata = metadata,
+    )
+
+    companion object {
+        /**
+         * Creates a spatial region of interest.
+         *
+         * @param shape The shape defining the spatial region.
+         * @param role The role of the region.
+         * @param description An optional description.
+         */
+        fun spatial(
+            shape: Shape,
+            role: Role? = null,
+            description: String? = null,
+        ) = RegionOfInterest(
+            region = listOf(RegionRange.spatial(shape)),
+            role = role,
+            description = description,
+        )
+
+        /**
+         * Creates a temporal region of interest.
+         *
+         * @param time The time range.
+         * @param role The role of the region.
+         * @param description An optional description.
+         */
+        fun temporal(
+            time: Time,
+            role: Role? = null,
+            description: String? = null,
+        ) = RegionOfInterest(
+            region = listOf(RegionRange.temporal(time)),
+            role = role,
+            description = description,
+        )
+    }
+}
+
+private fun ImageRegionType.toTypeString(): String = when (this) {
+    ImageRegionType.HUMAN -> "http://cv.iptc.org/newscodes/imageregiontype/human"
+    ImageRegionType.FACE -> "http://cv.iptc.org/newscodes/imageregiontype/face"
+    ImageRegionType.HEADSHOT -> "http://cv.iptc.org/newscodes/imageregiontype/headshot"
+    ImageRegionType.BODY_PART -> "http://cv.iptc.org/newscodes/imageregiontype/bodyPart"
+    ImageRegionType.ANIMAL -> "http://cv.iptc.org/newscodes/imageregiontype/animal"
+    ImageRegionType.PLANT -> "http://cv.iptc.org/newscodes/imageregiontype/plant"
+    ImageRegionType.PRODUCT -> "http://cv.iptc.org/newscodes/imageregiontype/product"
+    ImageRegionType.BUILDING -> "http://cv.iptc.org/newscodes/imageregiontype/building"
+    ImageRegionType.OBJECT -> "http://cv.iptc.org/newscodes/imageregiontype/object"
+    ImageRegionType.VEHICLE -> "http://cv.iptc.org/newscodes/imageregiontype/vehicle"
+    ImageRegionType.EVENT -> "http://cv.iptc.org/newscodes/imageregiontype/event"
+    ImageRegionType.ARTWORK -> "http://cv.iptc.org/newscodes/imageregiontype/artwork"
+    ImageRegionType.LOGO -> "http://cv.iptc.org/newscodes/imageregiontype/logo"
+    ImageRegionType.TEXT -> "http://cv.iptc.org/newscodes/imageregiontype/text"
+    ImageRegionType.VISIBLE_CODE -> "http://cv.iptc.org/newscodes/imageregiontype/visibleCode"
+    ImageRegionType.GEO_FEATURE -> "http://cv.iptc.org/newscodes/imageregiontype/geoFeature"
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/RegionRange.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/RegionRange.kt
@@ -1,0 +1,80 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a range within content that can be spatial, temporal, frame-based, textual, or identified.
+ *
+ * Only one of the range-specific properties should be set, corresponding to the [type].
+ *
+ * @property type The type of range (optional, can be inferred from which property is set).
+ * @property frame Frame range for video/animation content.
+ * @property time Temporal range for audio/video content.
+ * @property shape Spatial shape for image/video regions.
+ * @property text Textual range for document content.
+ * @property item Identified item within a container.
+ * @see RegionOfInterest
+ */
+@Serializable
+data class RegionRange(
+    val type: RangeType? = null,
+    val frame: Frame? = null,
+    val time: Time? = null,
+    val shape: Shape? = null,
+    val text: Text? = null,
+    val item: Item? = null,
+) {
+    companion object {
+        /**
+         * Creates a spatial region range from a shape.
+         */
+        fun spatial(shape: Shape) = RegionRange(
+            type = RangeType.SPATIAL,
+            shape = shape,
+        )
+
+        /**
+         * Creates a temporal region range from a time range.
+         */
+        fun temporal(time: Time) = RegionRange(
+            type = RangeType.TEMPORAL,
+            time = time,
+        )
+
+        /**
+         * Creates a frame-based region range.
+         */
+        fun frame(frame: Frame) = RegionRange(
+            type = RangeType.FRAME,
+            frame = frame,
+        )
+
+        /**
+         * Creates a textual region range.
+         */
+        fun textual(text: Text) = RegionRange(
+            type = RangeType.TEXTUAL,
+            text = text,
+        )
+
+        /**
+         * Creates an identified region range.
+         */
+        fun identified(item: Item) = RegionRange(
+            type = RangeType.IDENTIFIED,
+            item = item,
+        )
+    }
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/Relationship.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/Relationship.kt
@@ -1,0 +1,45 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Defines the relationship of an ingredient to its parent manifest.
+ *
+ * @see Ingredient
+ */
+@Serializable
+enum class Relationship {
+    /**
+     * The ingredient is the parent of the manifest.
+     * Used when an asset is opened and edited to create a new version.
+     */
+    @SerialName("parentOf")
+    PARENT_OF,
+
+    /**
+     * The ingredient is a component that was placed into the manifest.
+     * Used when an asset is composed from multiple sources.
+     */
+    @SerialName("componentOf")
+    COMPONENT_OF,
+
+    /**
+     * The ingredient was used as input to produce the manifest.
+     * Used when an asset is derived from or influenced by another asset.
+     */
+    @SerialName("inputTo")
+    INPUT_TO,
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ResourceRef.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ResourceRef.kt
@@ -1,0 +1,37 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Reference to a resource, either embedded or external.
+ *
+ * @property format The MIME type of the resource (e.g., "image/jpeg").
+ * @property identifier A unique identifier for the resource.
+ * @property hash The hash bytes of the resource.
+ * @property dataTypes The data types associated with this resource.
+ * @property alg The algorithm used for hashing.
+ * @see ManifestDefinition
+ * @see Ingredient
+ */
+@Serializable
+data class ResourceRef(
+    val format: String? = null,
+    val identifier: String? = null,
+    val hash: String? = null,
+    @SerialName("data_types")
+    val dataTypes: List<AssetType>? = null,
+    val alg: String? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ReviewRating.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ReviewRating.kt
@@ -1,0 +1,30 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a review rating for an assertion.
+ *
+ * @property code A code identifying the rating type.
+ * @property explanation A human-readable explanation of the rating.
+ * @property value The numeric rating value.
+ * @see Metadata
+ */
+@Serializable
+data class ReviewRating(
+    val code: String? = null,
+    val explanation: String? = null,
+    val value: Int? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/Role.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/Role.kt
@@ -1,0 +1,48 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Defines the role of a region within an asset.
+ *
+ * @see RegionOfInterest
+ */
+@Serializable
+enum class Role {
+    /** A general area of interest within the asset. */
+    @SerialName("c2pa.areaOfInterest")
+    AREA_OF_INTEREST,
+
+    /** A region that has been edited or modified. */
+    @SerialName("c2pa.edited")
+    EDITED,
+
+    /** A region where content was placed from another source. */
+    @SerialName("c2pa.placed")
+    PLACED,
+
+    /** A region that has been cropped. */
+    @SerialName("c2pa.cropped")
+    CROPPED,
+
+    /** A region that has been deleted or removed. */
+    @SerialName("c2pa.deleted")
+    DELETED,
+
+    /** A region where invisible watermark was added. */
+    @SerialName("c2pa.invisible")
+    INVISIBLE,
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/Shape.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/Shape.kt
@@ -1,0 +1,112 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a geometric shape for spatial regions.
+ *
+ * The shape type determines which properties are used:
+ * - [RECTANGLE][ShapeType.RECTANGLE]: Uses [origin], [width], and [height]
+ * - [CIRCLE][ShapeType.CIRCLE]: Uses [origin] (center) and [width] (diameter)
+ * - [POLYGON][ShapeType.POLYGON]: Uses [vertices]
+ *
+ * @property type The geometric type of the shape.
+ * @property origin The origin point (top-left for rectangles, center for circles).
+ * @property width The width for rectangles or diameter for circles.
+ * @property height The height for rectangles.
+ * @property vertices A list of coordinate points defining a polygon.
+ * @property inside Whether points inside (true) or outside (false) the shape are selected.
+ * @property unit The unit of measurement for coordinates.
+ * @see RegionRange
+ */
+@Serializable
+data class Shape(
+    val type: ShapeType,
+    val origin: Coordinate? = null,
+    val width: Double? = null,
+    val height: Double? = null,
+    val vertices: List<Coordinate>? = null,
+    val inside: Boolean? = null,
+    val unit: UnitType? = null,
+) {
+    companion object {
+        /**
+         * Creates a rectangular shape.
+         *
+         * @param x The x-coordinate of the top-left corner.
+         * @param y The y-coordinate of the top-left corner.
+         * @param width The width of the rectangle.
+         * @param height The height of the rectangle.
+         * @param unit The unit of measurement.
+         * @param inside Whether points inside the shape are selected.
+         */
+        fun rectangle(
+            x: Double,
+            y: Double,
+            width: Double,
+            height: Double,
+            unit: UnitType? = null,
+            inside: Boolean? = null,
+        ) = Shape(
+            type = ShapeType.RECTANGLE,
+            origin = Coordinate(x, y),
+            width = width,
+            height = height,
+            unit = unit,
+            inside = inside,
+        )
+
+        /**
+         * Creates a circular shape.
+         *
+         * @param centerX The x-coordinate of the center.
+         * @param centerY The y-coordinate of the center.
+         * @param diameter The diameter of the circle.
+         * @param unit The unit of measurement.
+         * @param inside Whether points inside the shape are selected.
+         */
+        fun circle(
+            centerX: Double,
+            centerY: Double,
+            diameter: Double,
+            unit: UnitType? = null,
+            inside: Boolean? = null,
+        ) = Shape(
+            type = ShapeType.CIRCLE,
+            origin = Coordinate(centerX, centerY),
+            width = diameter,
+            unit = unit,
+            inside = inside,
+        )
+
+        /**
+         * Creates a polygon shape.
+         *
+         * @param vertices The list of vertices defining the polygon.
+         * @param unit The unit of measurement.
+         * @param inside Whether points inside the shape are selected.
+         */
+        fun polygon(
+            vertices: List<Coordinate>,
+            unit: UnitType? = null,
+            inside: Boolean? = null,
+        ) = Shape(
+            type = ShapeType.POLYGON,
+            vertices = vertices,
+            unit = unit,
+            inside = inside,
+        )
+    }
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ShapeType.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ShapeType.kt
@@ -1,0 +1,36 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Defines the geometric shape type for spatial regions.
+ *
+ * @see Shape
+ */
+@Serializable
+enum class ShapeType {
+    /** A rectangular region defined by origin, width, and height. */
+    @SerialName("rectangle")
+    RECTANGLE,
+
+    /** A circular region defined by origin (center) and radius (via width). */
+    @SerialName("circle")
+    CIRCLE,
+
+    /** A polygon region defined by a list of vertices. */
+    @SerialName("polygon")
+    POLYGON,
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/StandardAssertionLabel.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/StandardAssertionLabel.kt
@@ -1,0 +1,98 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Standard C2PA assertion labels as defined in the C2PA specification.
+ *
+ * These labels identify the type of assertion in a manifest.
+ *
+ * @see AssertionDefinition
+ */
+@Serializable
+enum class StandardAssertionLabel {
+    /** Actions performed on the asset. */
+    @SerialName("c2pa.actions")
+    ACTIONS,
+
+    /** Actions performed on the asset (version 2). */
+    @SerialName("c2pa.actions.v2")
+    ACTIONS_V2,
+
+    /** Hash data for the asset. */
+    @SerialName("c2pa.hash.data")
+    HASH_DATA,
+
+    /** Box hash data. */
+    @SerialName("c2pa.hash.boxes")
+    HASH_BOXES,
+
+    /** BMFF v2 hash data. */
+    @SerialName("c2pa.hash.bmff.v2")
+    HASH_BMFF_V2,
+
+    /** Collection hash data. */
+    @SerialName("c2pa.hash.collection")
+    HASH_COLLECTION,
+
+    /** Soft binding assertion. */
+    @SerialName("c2pa.soft-binding")
+    SOFT_BINDING,
+
+    /** Cloud data assertion. */
+    @SerialName("c2pa.cloud-data")
+    CLOUD_DATA,
+
+    /** Thumbnail claim assertion. */
+    @SerialName("c2pa.thumbnail.claim")
+    THUMBNAIL_CLAIM,
+
+    /** Ingredient thumbnail assertion. */
+    @SerialName("c2pa.thumbnail.ingredient")
+    THUMBNAIL_INGREDIENT,
+
+    /** Depthmap assertion. */
+    @SerialName("c2pa.depthmap")
+    DEPTHMAP,
+
+    /** Training/Mining assertion. */
+    @SerialName("c2pa.training-mining")
+    TRAINING_MINING,
+
+    /** EXIF metadata assertion. */
+    @SerialName("stds.exif")
+    EXIF,
+
+    /** Schema.org Creative Work assertion. */
+    @SerialName("stds.schema-org.CreativeWork")
+    CREATIVE_WORK,
+
+    /** IPTC photo metadata assertion. */
+    @SerialName("stds.iptc.photo-metadata")
+    IPTC_PHOTO_METADATA,
+
+    /** ISO location assertion. */
+    @SerialName("stds.iso.location.v1")
+    ISO_LOCATION,
+
+    /** CAWG identity assertion. */
+    @SerialName("cawg.identity")
+    CAWG_IDENTITY,
+
+    /** CAWG AI training and data mining assertion. */
+    @SerialName("cawg.ai_training_and_data_mining")
+    CAWG_AI_TRAINING,
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/StatusCodes.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/StatusCodes.kt
@@ -1,0 +1,31 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Groups validation statuses by their outcome category.
+ *
+ * @property success List of successful validation statuses.
+ * @property failure List of failed validation statuses.
+ * @property informational List of informational validation statuses.
+ * @see ValidationStatus
+ * @see ValidationResults
+ */
+@Serializable
+data class StatusCodes(
+    val success: List<ValidationStatus>? = null,
+    val failure: List<ValidationStatus>? = null,
+    val informational: List<ValidationStatus>? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/Text.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/Text.kt
@@ -1,0 +1,26 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a textual region within document content.
+ *
+ * @property selectors The list of text selector ranges defining the region.
+ * @see RegionRange
+ */
+@Serializable
+data class Text(
+    val selectors: List<TextSelectorRange>,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/TextSelector.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/TextSelector.kt
@@ -1,0 +1,32 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a text fragment selector for textual regions.
+ *
+ * Can specify text by fragment string and/or character positions.
+ *
+ * @property fragment A text fragment to match.
+ * @property start The starting character position (inclusive).
+ * @property end The ending character position (exclusive).
+ * @see TextSelectorRange
+ */
+@Serializable
+data class TextSelector(
+    val fragment: String? = null,
+    val start: Int? = null,
+    val end: Int? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/TextSelectorRange.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/TextSelectorRange.kt
@@ -1,0 +1,30 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a range of text defined by selector(s).
+ *
+ * Can specify a single point or a range using start and end selectors.
+ *
+ * @property selector The starting selector.
+ * @property end The optional ending selector for a range.
+ * @see Text
+ */
+@Serializable
+data class TextSelectorRange(
+    val selector: TextSelector,
+    val end: TextSelector? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/Time.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/Time.kt
@@ -1,0 +1,33 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a temporal range for audio or video content.
+ *
+ * Times are specified as strings in the format defined by [type].
+ * For NPT (Normal Play Time), values like "0:00:00", "1:30:00", or seconds like "90" are valid.
+ *
+ * @property start The start time as a string.
+ * @property end The end time as a string.
+ * @property type The time format type.
+ * @see RegionRange
+ */
+@Serializable
+data class Time(
+    val start: String? = null,
+    val end: String? = null,
+    val type: TimeType? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/TimeType.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/TimeType.kt
@@ -1,0 +1,28 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Defines the time format for temporal regions.
+ *
+ * @see Time
+ */
+@Serializable
+enum class TimeType {
+    /** Normal Play Time format (npt). */
+    @SerialName("npt")
+    NPT,
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/UnitType.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/UnitType.kt
@@ -1,0 +1,32 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Defines the measurement unit for spatial coordinates.
+ *
+ * @see Shape
+ */
+@Serializable
+enum class UnitType {
+    /** Coordinates are in pixels. */
+    @SerialName("pixel")
+    PIXEL,
+
+    /** Coordinates are in percentages of the asset dimensions. */
+    @SerialName("percent")
+    PERCENT,
+}

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/UriOrResource.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/UriOrResource.kt
@@ -1,0 +1,30 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Base type for URI or embedded resource references.
+ *
+ * Provides common properties for referencing external URIs or embedded resources
+ * with optional algorithm specification.
+ *
+ * @property alg The algorithm used for hashing (e.g., "sha256").
+ * @see ResourceRef
+ * @see HashedUri
+ */
+@Serializable
+data class UriOrResource(
+    val alg: String? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ValidationResults.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ValidationResults.kt
@@ -1,0 +1,32 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Contains validation results for an ingredient.
+ *
+ * @property activeManifest The validation status for the active manifest.
+ * @property ingredientDeltas Validation results for ingredient deltas.
+ * @see Ingredient
+ * @see IngredientDeltaValidationResult
+ */
+@Serializable
+data class ValidationResults(
+    @SerialName("active_manifest")
+    val activeManifest: StatusCodes? = null,
+    @SerialName("ingredient_deltas")
+    val ingredientDeltas: List<IngredientDeltaValidationResult>? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ValidationStatus.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ValidationStatus.kt
@@ -1,0 +1,33 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the validation status of a manifest or ingredient.
+ *
+ * @property code The validation status code.
+ * @property explanation A human-readable explanation of the status.
+ * @property success Whether this status indicates success.
+ * @property url An optional URL with more information about this status.
+ * @see ValidationStatusCode
+ * @see Ingredient
+ */
+@Serializable
+data class ValidationStatus(
+    val code: ValidationStatusCode,
+    val explanation: String? = null,
+    val success: Boolean? = null,
+    val url: String? = null,
+)

--- a/library/src/main/kotlin/org/contentauth/c2pa/manifest/ValidationStatusCode.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/manifest/ValidationStatusCode.kt
@@ -1,0 +1,185 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.manifest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Validation status codes as defined in the C2PA specification.
+ *
+ * These codes indicate the result of various validation checks performed on manifests.
+ *
+ * @see ValidationStatus
+ */
+@Serializable
+enum class ValidationStatusCode {
+    // Success codes
+    @SerialName("claimSignature.validated")
+    CLAIM_SIGNATURE_VALIDATED,
+
+    @SerialName("signingCredential.trusted")
+    SIGNING_CREDENTIAL_TRUSTED,
+
+    @SerialName("timeStamp.trusted")
+    TIMESTAMP_TRUSTED,
+
+    @SerialName("assertion.dataHash.match")
+    ASSERTION_DATA_HASH_MATCH,
+
+    @SerialName("assertion.bmffHash.match")
+    ASSERTION_BMFF_HASH_MATCH,
+
+    @SerialName("assertion.boxesHash.match")
+    ASSERTION_BOXES_HASH_MATCH,
+
+    @SerialName("assertion.collectionHash.match")
+    ASSERTION_COLLECTION_HASH_MATCH,
+
+    @SerialName("assertion.hashedURI.match")
+    ASSERTION_HASHED_URI_MATCH,
+
+    @SerialName("assertion.ingredientMatch")
+    ASSERTION_INGREDIENT_MATCH,
+
+    @SerialName("assertion.accessible")
+    ASSERTION_ACCESSIBLE,
+
+    // Failure codes
+    @SerialName("assertion.dataHash.mismatch")
+    ASSERTION_DATA_HASH_MISMATCH,
+
+    @SerialName("assertion.bmffHash.mismatch")
+    ASSERTION_BMFF_HASH_MISMATCH,
+
+    @SerialName("assertion.boxesHash.mismatch")
+    ASSERTION_BOXES_HASH_MISMATCH,
+
+    @SerialName("assertion.collectionHash.mismatch")
+    ASSERTION_COLLECTION_HASH_MISMATCH,
+
+    @SerialName("assertion.hashedURI.mismatch")
+    ASSERTION_HASHED_URI_MISMATCH,
+
+    @SerialName("assertion.missing")
+    ASSERTION_MISSING,
+
+    @SerialName("assertion.multipleHardBindings")
+    ASSERTION_MULTIPLE_HARD_BINDINGS,
+
+    @SerialName("assertion.undeclaredHashedURI")
+    ASSERTION_UNDECLARED_HASHED_URI,
+
+    @SerialName("assertion.requiredMissing")
+    ASSERTION_REQUIRED_MISSING,
+
+    @SerialName("assertion.inaccessible")
+    ASSERTION_INACCESSIBLE,
+
+    @SerialName("assertion.cloudData.hardBinding")
+    ASSERTION_CLOUD_DATA_HARD_BINDING,
+
+    @SerialName("assertion.cloudData.actions")
+    ASSERTION_CLOUD_DATA_ACTIONS,
+
+    @SerialName("assertion.cloudData.mismatch")
+    ASSERTION_CLOUD_DATA_MISMATCH,
+
+    @SerialName("assertion.json.invalid")
+    ASSERTION_JSON_INVALID,
+
+    @SerialName("assertion.cbor.invalid")
+    ASSERTION_CBOR_INVALID,
+
+    @SerialName("assertion.action.ingredientMismatch")
+    ASSERTION_ACTION_INGREDIENT_MISMATCH,
+
+    @SerialName("assertion.action.missing")
+    ASSERTION_ACTION_MISSING,
+
+    @SerialName("assertion.action.redactionMissing")
+    ASSERTION_ACTION_REDACTION_MISSING,
+
+    @SerialName("assertion.selfRedacted")
+    ASSERTION_SELF_REDACTED,
+
+    @SerialName("claim.missing")
+    CLAIM_MISSING,
+
+    @SerialName("claim.multiple")
+    CLAIM_MULTIPLE,
+
+    @SerialName("claim.hardBindings.missing")
+    CLAIM_HARD_BINDINGS_MISSING,
+
+    @SerialName("claim.required.missing")
+    CLAIM_REQUIRED_MISSING,
+
+    @SerialName("claim.cbor.invalid")
+    CLAIM_CBOR_INVALID,
+
+    @SerialName("claimSignature.mismatch")
+    CLAIM_SIGNATURE_MISMATCH,
+
+    @SerialName("claimSignature.missing")
+    CLAIM_SIGNATURE_MISSING,
+
+    @SerialName("manifest.missing")
+    MANIFEST_MISSING,
+
+    @SerialName("manifest.multipleParents")
+    MANIFEST_MULTIPLE_PARENTS,
+
+    @SerialName("manifest.updateWrongParents")
+    MANIFEST_UPDATE_WRONG_PARENTS,
+
+    @SerialName("manifest.inaccessible")
+    MANIFEST_INACCESSIBLE,
+
+    @SerialName("ingredient.hashedURI.mismatch")
+    INGREDIENT_HASHED_URI_MISMATCH,
+
+    @SerialName("signingCredential.untrusted")
+    SIGNING_CREDENTIAL_UNTRUSTED,
+
+    @SerialName("signingCredential.invalid")
+    SIGNING_CREDENTIAL_INVALID,
+
+    @SerialName("signingCredential.revoked")
+    SIGNING_CREDENTIAL_REVOKED,
+
+    @SerialName("signingCredential.expired")
+    SIGNING_CREDENTIAL_EXPIRED,
+
+    @SerialName("timeStamp.mismatch")
+    TIMESTAMP_MISMATCH,
+
+    @SerialName("timeStamp.untrusted")
+    TIMESTAMP_UNTRUSTED,
+
+    @SerialName("timeStamp.outsideValidity")
+    TIMESTAMP_OUTSIDE_VALIDITY,
+
+    @SerialName("algorithm.unsupported")
+    ALGORITHM_UNSUPPORTED,
+
+    @SerialName("general.error")
+    GENERAL_ERROR,
+
+    // Additional status codes
+    @SerialName("assertion.redactedUriMismatch")
+    ASSERTION_REDACTED_URI_MISMATCH,
+
+    @SerialName("assertion.notRedactable")
+    ASSERTION_NOT_REDACTABLE,
+}

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.contentauth.c2pa.test.shared.BuilderTests
 import org.contentauth.c2pa.test.shared.CoreTests
+import org.contentauth.c2pa.test.shared.ManifestTests
 import org.contentauth.c2pa.test.shared.SignerTests
 import org.contentauth.c2pa.test.shared.StreamTests
 import org.contentauth.c2pa.test.shared.TestBase
@@ -128,6 +129,16 @@ private class AppWebServiceTests(private val context: Context) : WebServiceTests
         copyResourceToCache(context, resourceName, fileName)
 }
 
+private class AppManifestTests(private val context: Context) : ManifestTests() {
+    override fun getContext(): Context = context
+    override fun loadResourceAsBytes(resourceName: String): ByteArray = loadResourceWithExtensions(resourceName)
+        ?: throw IllegalArgumentException("Resource not found: $resourceName")
+    override fun loadResourceAsString(resourceName: String): String = loadResourceStringWithExtensions(resourceName)
+        ?: throw IllegalArgumentException("Resource not found: $resourceName")
+    override fun copyResourceToFile(resourceName: String, fileName: String): File =
+        copyResourceToCache(context, resourceName, fileName)
+}
+
 /** Run all tests from all test suites */
 private suspend fun runAllTests(context: Context): List<TestResult> = withContext(Dispatchers.IO) {
     val results = mutableListOf<TestResult>()
@@ -143,6 +154,8 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(coreTests.testLoadSettings())
     results.add(coreTests.testInvalidInputs())
     results.add(coreTests.testErrorEnumCoverage())
+    results.add(coreTests.testReaderDetailedJson())
+    results.add(coreTests.testReaderIsEmbedded())
 
     // Stream Tests
     val streamTests = AppStreamTests(context)
@@ -162,6 +175,8 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBuilderFromArchive())
     results.add(builderTests.testReaderWithManifestData())
     results.add(builderTests.testJsonRoundTrip())
+    results.add(builderTests.testBuilderSetIntent())
+    results.add(builderTests.testBuilderAddAction())
 
     // Signer Tests
     val signerTests = AppSignerTests(context)
@@ -172,6 +187,12 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(signerTests.testSignerReserveSize())
     results.add(signerTests.testSignFile())
     results.add(signerTests.testAlgorithmCoverage())
+    results.add(signerTests.testKeyStoreSignerIntegration())
+    results.add(signerTests.testStrongBoxSignerIntegration())
+    results.add(signerTests.testKeyStoreSignerKeyManagement())
+    results.add(signerTests.testStrongBoxAvailability())
+    results.add(signerTests.testSignerFromSettingsToml())
+    results.add(signerTests.testSignerFromSettingsJson())
 
     // Web Service Tests (if server is available)
     val webServiceTests = AppWebServiceTests(context)
@@ -185,6 +206,28 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
 
     // Additional Stream Tests (large buffer handling)
     results.add(streamTests.testLargeBufferHandling())
+
+    // Manifest Tests
+    val manifestTests = AppManifestTests(context)
+    results.add(manifestTests.testMinimal())
+    results.add(manifestTests.testCreated())
+    results.add(manifestTests.testEnumRendering())
+    results.add(manifestTests.testRegionOfInterest())
+    results.add(manifestTests.testResourceRef())
+    results.add(manifestTests.testHashedUri())
+    results.add(manifestTests.testUriOrResource())
+    results.add(manifestTests.testMassInit())
+    results.add(manifestTests.testManifestToJson())
+    results.add(manifestTests.testShapeFactoryMethods())
+    results.add(manifestTests.testManifestWithBuilder())
+    results.add(manifestTests.testAllAssertionTypes())
+    results.add(manifestTests.testIngredients())
+    results.add(manifestTests.testActionWithRegions())
+    results.add(manifestTests.testMalformedJson())
+    results.add(manifestTests.testSpecialCharacters())
+    results.add(manifestTests.testCreatedFactory())
+    results.add(manifestTests.testAllValidationStatusCodes())
+    results.add(manifestTests.testAllDigitalSourceTypes())
 
     results
 }

--- a/test-shared/build.gradle.kts
+++ b/test-shared/build.gradle.kts
@@ -60,6 +60,9 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
 
+    // Serialization for JSON tests
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+
     // OkHttp for web service tests
     implementation("com.squareup.okhttp3:okhttp:5.1.0")
 }

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/ManifestTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/ManifestTests.kt
@@ -1,0 +1,1313 @@
+/*
+This file is licensed to you under the Apache License, Version 2.0
+(http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+(http://opensource.org/licenses/MIT), at your option.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+files for the specific language governing permissions and limitations under
+each license.
+*/
+
+package org.contentauth.c2pa.test.shared
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.contentauth.c2pa.DigitalSourceType
+import org.contentauth.c2pa.PredefinedAction
+import org.contentauth.c2pa.manifest.ActionAssertion
+import org.contentauth.c2pa.manifest.AssetType
+import org.contentauth.c2pa.manifest.AssertionDefinition
+import org.contentauth.c2pa.manifest.ClaimGeneratorInfo
+import org.contentauth.c2pa.manifest.Coordinate
+import org.contentauth.c2pa.manifest.DataSource
+import org.contentauth.c2pa.manifest.Frame
+import org.contentauth.c2pa.manifest.HashedUri
+import org.contentauth.c2pa.manifest.ImageRegionType
+import org.contentauth.c2pa.manifest.Ingredient
+import org.contentauth.c2pa.manifest.IngredientDeltaValidationResult
+import org.contentauth.c2pa.manifest.Item
+import org.contentauth.c2pa.manifest.ManifestDefinition
+import org.contentauth.c2pa.manifest.Metadata
+import org.contentauth.c2pa.manifest.MetadataActor
+import org.contentauth.c2pa.manifest.RangeType
+import org.contentauth.c2pa.manifest.RegionOfInterest
+import org.contentauth.c2pa.manifest.RegionRange
+import org.contentauth.c2pa.manifest.ResourceRef
+import org.contentauth.c2pa.manifest.ReviewRating
+import org.contentauth.c2pa.manifest.Shape
+import org.contentauth.c2pa.manifest.ShapeType
+import org.contentauth.c2pa.manifest.StatusCodes
+import org.contentauth.c2pa.manifest.Text
+import org.contentauth.c2pa.manifest.TextSelector
+import org.contentauth.c2pa.manifest.TextSelectorRange
+import org.contentauth.c2pa.manifest.Time
+import org.contentauth.c2pa.manifest.UnitType
+import org.contentauth.c2pa.manifest.UriOrResource
+import org.contentauth.c2pa.manifest.ValidationResults
+import org.contentauth.c2pa.manifest.ValidationStatus
+import org.contentauth.c2pa.manifest.ValidationStatusCode
+import org.contentauth.c2pa.manifest.Relationship
+import org.contentauth.c2pa.manifest.TrainingMiningEntry
+import org.contentauth.c2pa.Builder
+import org.contentauth.c2pa.ByteArrayStream
+import org.contentauth.c2pa.C2PA
+import org.contentauth.c2pa.FileStream
+import org.contentauth.c2pa.Signer
+import org.contentauth.c2pa.SignerInfo
+import org.contentauth.c2pa.SigningAlgorithm
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.json.JSONObject
+import java.io.File
+
+abstract class ManifestTests : TestBase() {
+
+    /**
+     * Tests minimal ManifestDefinition creation.
+     */
+    suspend fun testMinimal(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Manifest Minimal") {
+            val manifest = ManifestDefinition(
+                title = "test",
+                claimGeneratorInfo = listOf(
+                    ClaimGeneratorInfo(name = "test_app"),
+                ),
+            )
+
+            if (manifest.title != "test") {
+                return@runTest TestResult(
+                    "Manifest Minimal",
+                    false,
+                    "title != test",
+                    "Got: ${manifest.title}",
+                )
+            }
+
+            if (manifest.claimGeneratorInfo.isEmpty()) {
+                return@runTest TestResult(
+                    "Manifest Minimal",
+                    false,
+                    "claimGeneratorInfo is empty",
+                )
+            }
+
+            // Test JSON round-trip
+            cloneAndCompare(manifest, "Manifest Minimal")
+        }
+    }
+
+    /**
+     * Tests ManifestDefinition with actions assertion.
+     */
+    suspend fun testCreated(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Manifest Created") {
+            val manifest = ManifestDefinition(
+                title = "test",
+                claimGeneratorInfo = listOf(
+                    ClaimGeneratorInfo(
+                        name = "test_app",
+                        version = "1.0.0",
+                        operatingSystem = ClaimGeneratorInfo.operatingSystem,
+                    ),
+                ),
+                assertions = listOf(
+                    AssertionDefinition.actions(
+                        listOf(
+                            ActionAssertion(
+                                action = PredefinedAction.CREATED,
+                                digitalSourceType = DigitalSourceType.DIGITAL_CAPTURE,
+                            ),
+                        ),
+                    ),
+                ),
+            )
+
+            val assertion = manifest.assertions.firstOrNull()
+            if (assertion == null) {
+                return@runTest TestResult(
+                    "Manifest Created",
+                    false,
+                    "manifest.assertions.first == null",
+                )
+            }
+
+            if (assertion !is AssertionDefinition.Actions) {
+                return@runTest TestResult(
+                    "Manifest Created",
+                    false,
+                    "manifest.assertions.first is not Actions",
+                    "Got: ${assertion::class.simpleName}",
+                )
+            }
+
+            val action = assertion.actions.firstOrNull()
+            if (action == null) {
+                return@runTest TestResult(
+                    "Manifest Created",
+                    false,
+                    "actions.first == null",
+                )
+            }
+
+            if (action.action != "c2pa.created") {
+                return@runTest TestResult(
+                    "Manifest Created",
+                    false,
+                    "action.action != c2pa.created",
+                    "Got: ${action.action}",
+                )
+            }
+
+            val expectedSourceType = "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCapture"
+            if (action.digitalSourceType != expectedSourceType) {
+                return@runTest TestResult(
+                    "Manifest Created",
+                    false,
+                    "action.digitalSourceType incorrect",
+                    "Expected: $expectedSourceType, Got: ${action.digitalSourceType}",
+                )
+            }
+
+            val info = manifest.claimGeneratorInfo.firstOrNull()
+            if (info == null) {
+                return@runTest TestResult(
+                    "Manifest Created",
+                    false,
+                    "claimGeneratorInfo.first == null",
+                )
+            }
+
+            if (info.name != "test_app") {
+                return@runTest TestResult(
+                    "Manifest Created",
+                    false,
+                    "claimGeneratorInfo.name != test_app",
+                    "Got: ${info.name}",
+                )
+            }
+
+            // Test JSON round-trip
+            cloneAndCompare(manifest, "Manifest Created")
+        }
+    }
+
+    /**
+     * Tests Shape creation and equality.
+     */
+    suspend fun testEnumRendering(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Manifest Enum Rendering") {
+            val shape = Shape(
+                type = ShapeType.RECTANGLE,
+                origin = Coordinate(10.0, 10.0),
+                width = 80.0,
+                height = 80.0,
+                unit = UnitType.PERCENT,
+            )
+
+            // Create another identical shape
+            val shape2 = Shape(
+                type = ShapeType.RECTANGLE,
+                origin = Coordinate(10.0, 10.0),
+                width = 80.0,
+                height = 80.0,
+                unit = UnitType.PERCENT,
+            )
+
+            if (shape == shape2) {
+                TestResult(
+                    "Manifest Enum Rendering",
+                    true,
+                    "Shape enums rendered as expected",
+                    "Shape type: ${shape.type}, unit: ${shape.unit}",
+                )
+            } else {
+                TestResult(
+                    "Manifest Enum Rendering",
+                    false,
+                    "Shapes unexpectedly unequal",
+                    "shape: $shape, shape2: $shape2",
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests RegionOfInterest structure equality.
+     */
+    suspend fun testRegionOfInterest(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Manifest RegionOfInterest") {
+            val rr = RegionRange(type = RangeType.FRAME)
+
+            val roi1 = RegionOfInterest(
+                region = listOf(rr),
+                imageRegionType = ImageRegionType.ANIMAL,
+            )
+            val roi2 = RegionOfInterest(
+                region = listOf(rr),
+                imageRegionType = ImageRegionType.ANIMAL,
+            )
+
+            if (roi1 == roi2) {
+                TestResult(
+                    "Manifest RegionOfInterest",
+                    true,
+                    "RegionOfInterests equal",
+                )
+            } else {
+                TestResult(
+                    "Manifest RegionOfInterest",
+                    false,
+                    "RegionOfInterests unexpectedly unequal",
+                    "roi1: $roi1, roi2: $roi2",
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests ResourceRef equality.
+     */
+    suspend fun testResourceRef(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Manifest ResourceRef") {
+            val r1 = ResourceRef(format = "application/octet-stream", identifier = "")
+            val r2 = ResourceRef(format = "application/octet-stream", identifier = "")
+
+            if (r1 == r2) {
+                TestResult(
+                    "Manifest ResourceRef",
+                    true,
+                    "ResourceRefs equal",
+                    "ResourceRef: $r1",
+                )
+            } else {
+                TestResult(
+                    "Manifest ResourceRef",
+                    false,
+                    "ResourceRefs unexpectedly unequal",
+                    "r1: $r1, r2: $r2",
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests HashedUri equality.
+     */
+    suspend fun testHashedUri(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Manifest HashedUri") {
+            val hu1 = HashedUri(hash = "", url = "foo")
+            val hu2 = HashedUri(hash = "", url = "foo")
+
+            if (hu1 == hu2) {
+                TestResult(
+                    "Manifest HashedUri",
+                    true,
+                    "HashedUris equal",
+                    "HashedUri: $hu1",
+                )
+            } else {
+                TestResult(
+                    "Manifest HashedUri",
+                    false,
+                    "HashedUris unexpectedly unequal",
+                    "hu1: $hu1, hu2: $hu2",
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests UriOrResource equality.
+     */
+    suspend fun testUriOrResource(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Manifest UriOrResource") {
+            val uor1 = UriOrResource(alg = "foo")
+            val uor2 = UriOrResource(alg = "foo")
+
+            if (uor1 == uor2) {
+                TestResult(
+                    "Manifest UriOrResource",
+                    true,
+                    "UriOrResources equal",
+                )
+            } else {
+                TestResult(
+                    "Manifest UriOrResource",
+                    false,
+                    "UriOrResources unexpectedly unequal",
+                    "uor1: $uor1, uor2: $uor2",
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests bulk initialization of various manifest-related types.
+     */
+    suspend fun testMassInit(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Manifest Mass Init") {
+            try {
+                // Test all type initializations
+                val ingredient = Ingredient()
+                val statusCodes = StatusCodes(failure = emptyList(), informational = emptyList(), success = emptyList())
+                val metadata = Metadata()
+                val validationStatus = ValidationStatus(code = ValidationStatusCode.ALGORITHM_UNSUPPORTED)
+                val time = Time()
+                val textSelector = TextSelector(fragment = "")
+                val reviewRating = ReviewRating(explanation = "", value = 1)
+                val dataSource = DataSource(type = "")
+                val metadataActor = MetadataActor()
+                val validationResults = ValidationResults()
+                val ingredientDelta = IngredientDeltaValidationResult(
+                    ingredientAssertionUri = "",
+                    validationDeltas = statusCodes,
+                )
+                val item = Item(identifier = "track_id", value = "2")
+                val assetType = AssetType(type = "")
+                val frame = Frame()
+                val textSelectorRange = TextSelectorRange(selector = textSelector)
+                val text = Text(selectors = listOf(textSelectorRange))
+
+                // Verify all objects initialized
+                val allInitialized = listOf(
+                    ingredient,
+                    statusCodes,
+                    metadata,
+                    validationStatus,
+                    time,
+                    textSelector,
+                    reviewRating,
+                    dataSource,
+                    metadataActor,
+                    validationResults,
+                    ingredientDelta,
+                    item,
+                    assetType,
+                    frame,
+                    textSelectorRange,
+                    text,
+                ).all { it != null }
+
+                if (allInitialized) {
+                    TestResult(
+                        "Manifest Mass Init",
+                        true,
+                        "All objects initialize correctly",
+                        "16 types successfully initialized",
+                    )
+                } else {
+                    TestResult(
+                        "Manifest Mass Init",
+                        false,
+                        "Some objects failed to initialize",
+                    )
+                }
+            } catch (e: Exception) {
+                TestResult(
+                    "Manifest Mass Init",
+                    false,
+                    "Error during initialization: ${e.message}",
+                    e.stackTraceToString(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests ManifestDefinition.toJson() produces valid JSON for Builder.
+     */
+    suspend fun testManifestToJson(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Manifest to JSON") {
+            val manifest = ManifestDefinition(
+                title = "Test Photo",
+                claimGeneratorInfo = listOf(
+                    ClaimGeneratorInfo(
+                        name = "TestApp",
+                        version = "1.0",
+                    ),
+                ),
+                assertions = listOf(
+                    AssertionDefinition.actions(
+                        listOf(
+                            ActionAssertion.created(DigitalSourceType.DIGITAL_CAPTURE),
+                        ),
+                    ),
+                ),
+            )
+
+            try {
+                val jsonString = manifest.toJson()
+
+                // Verify it's valid JSON by parsing it
+                val parsed = ManifestDefinition.fromJson(jsonString)
+
+                if (parsed.title == manifest.title &&
+                    parsed.claimGeneratorInfo.size == manifest.claimGeneratorInfo.size
+                ) {
+                    TestResult(
+                        "Manifest to JSON",
+                        true,
+                        "ManifestDefinition.toJson() produces valid JSON",
+                        "JSON: ${jsonString.take(200)}...",
+                    )
+                } else {
+                    TestResult(
+                        "Manifest to JSON",
+                        false,
+                        "Parsed manifest does not match original",
+                        "Original title: ${manifest.title}, Parsed title: ${parsed.title}",
+                    )
+                }
+            } catch (e: Exception) {
+                TestResult(
+                    "Manifest to JSON",
+                    false,
+                    "Error: ${e.message}",
+                    e.stackTraceToString(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests Shape factory methods.
+     */
+    suspend fun testShapeFactoryMethods(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Manifest Shape Factory") {
+            try {
+                val rectangle = Shape.rectangle(
+                    x = 10.0,
+                    y = 20.0,
+                    width = 100.0,
+                    height = 50.0,
+                    unit = UnitType.PIXEL,
+                )
+
+                val circle = Shape.circle(
+                    centerX = 50.0,
+                    centerY = 50.0,
+                    diameter = 40.0,
+                    unit = UnitType.PERCENT,
+                )
+
+                val polygon = Shape.polygon(
+                    vertices = listOf(
+                        Coordinate(0.0, 0.0),
+                        Coordinate(100.0, 0.0),
+                        Coordinate(50.0, 100.0),
+                    ),
+                )
+
+                val allValid = rectangle.type == ShapeType.RECTANGLE &&
+                    circle.type == ShapeType.CIRCLE &&
+                    polygon.type == ShapeType.POLYGON &&
+                    rectangle.origin?.x == 10.0 &&
+                    circle.origin?.x == 50.0 &&
+                    polygon.vertices?.size == 3
+
+                if (allValid) {
+                    TestResult(
+                        "Manifest Shape Factory",
+                        true,
+                        "Shape factory methods work correctly",
+                        "Rectangle: $rectangle, Circle: $circle, Polygon vertices: ${polygon.vertices?.size}",
+                    )
+                } else {
+                    TestResult(
+                        "Manifest Shape Factory",
+                        false,
+                        "Shape factory methods produced invalid shapes",
+                    )
+                }
+            } catch (e: Exception) {
+                TestResult(
+                    "Manifest Shape Factory",
+                    false,
+                    "Error: ${e.message}",
+                    e.stackTraceToString(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests that ManifestDefinition.toJson() produces JSON that Builder accepts.
+     * This is the critical integration test - if this fails, the manifest types are broken.
+     */
+    suspend fun testManifestWithBuilder(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Manifest with Builder") {
+            try {
+                val manifest = ManifestDefinition(
+                    title = "Builder Integration Test",
+                    claimGeneratorInfo = listOf(
+                        ClaimGeneratorInfo(
+                            name = "C2PA Android Test",
+                            version = "1.0.0",
+                        ),
+                    ),
+                    assertions = listOf(
+                        AssertionDefinition.actions(
+                            listOf(
+                                ActionAssertion.created(DigitalSourceType.DIGITAL_CAPTURE),
+                            ),
+                        ),
+                    ),
+                )
+
+                val jsonString = manifest.toJson()
+
+                // Try to create a Builder from our manifest JSON
+                val builder = Builder.fromJson(jsonString)
+                try {
+                    val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+                    val sourceStream = ByteArrayStream(sourceImageData)
+
+                    val outputFile = File.createTempFile("manifest-builder-test", ".jpg")
+                    val destStream = FileStream(outputFile)
+                    try {
+                        val certPem = loadResourceAsString("es256_certs")
+                        val keyPem = loadResourceAsString("es256_private")
+
+                        val signerInfo = SignerInfo(SigningAlgorithm.ES256, certPem, keyPem)
+                        val signer = Signer.fromInfo(signerInfo)
+
+                        try {
+                            builder.sign("image/jpeg", sourceStream, destStream, signer)
+
+                            // Read back and verify
+                            val readManifest = C2PA.readFile(outputFile.absolutePath)
+                            val json = JSONObject(readManifest)
+
+                            if (!json.has("manifests")) {
+                                return@runTest TestResult(
+                                    "Manifest with Builder",
+                                    false,
+                                    "Signed file has no manifests",
+                                )
+                            }
+
+                            // Verify our title made it through
+                            val manifests = json.getJSONObject("manifests")
+                            val keys = manifests.keys()
+                            if (!keys.hasNext()) {
+                                return@runTest TestResult(
+                                    "Manifest with Builder",
+                                    false,
+                                    "No manifest entries found",
+                                )
+                            }
+
+                            val firstManifest = manifests.getJSONObject(keys.next())
+                            val title = firstManifest.optString("title", "")
+
+                            if (title != "Builder Integration Test") {
+                                return@runTest TestResult(
+                                    "Manifest with Builder",
+                                    false,
+                                    "Title mismatch",
+                                    "Expected: 'Builder Integration Test', Got: '$title'",
+                                )
+                            }
+
+                            TestResult(
+                                "Manifest with Builder",
+                                true,
+                                "ManifestDefinition successfully used with Builder",
+                                "Signed file: ${outputFile.length()} bytes",
+                            )
+                        } finally {
+                            signer.close()
+                        }
+                    } finally {
+                        sourceStream.close()
+                        destStream.close()
+                        outputFile.delete()
+                    }
+                } finally {
+                    builder.close()
+                }
+            } catch (e: Exception) {
+                TestResult(
+                    "Manifest with Builder",
+                    false,
+                    "Error: ${e.message}",
+                    e.stackTraceToString(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests all assertion types serialize and deserialize correctly.
+     */
+    suspend fun testAllAssertionTypes(): TestResult = withContext(Dispatchers.IO) {
+        runTest("All Assertion Types") {
+            try {
+                val manifest = ManifestDefinition(
+                    title = "Multi-Assertion Test",
+                    claimGeneratorInfo = listOf(ClaimGeneratorInfo(name = "test")),
+                    assertions = listOf(
+                        // Actions assertion
+                        AssertionDefinition.actions(
+                            listOf(
+                                ActionAssertion.created(DigitalSourceType.DIGITAL_CAPTURE),
+                                ActionAssertion.edited(softwareAgent = "PhotoEditor 2.0"),
+                            ),
+                        ),
+                        // CreativeWork assertion
+                        AssertionDefinition.creativeWork(
+                            mapOf(
+                                "@context" to JsonPrimitive("https://schema.org"),
+                                "@type" to JsonPrimitive("Photograph"),
+                                "author" to buildJsonObject {
+                                    put("@type", "Person")
+                                    put("name", "Test Author")
+                                },
+                            ),
+                        ),
+                        // Training/Mining assertion
+                        AssertionDefinition.trainingMining(
+                            listOf(
+                                TrainingMiningEntry(
+                                    use = "notAllowed",
+                                    constraintInfo = "No AI training permitted",
+                                ),
+                            ),
+                        ),
+                        // Custom assertion
+                        AssertionDefinition.custom(
+                            label = "com.example.custom",
+                            data = buildJsonObject {
+                                put("customField", "customValue")
+                                put("version", 1)
+                            },
+                        ),
+                    ),
+                )
+
+                val jsonString = manifest.toJson()
+                val parsed = ManifestDefinition.fromJson(jsonString)
+
+                // Verify all assertions survived the round-trip
+                if (parsed.assertions.size != 4) {
+                    return@runTest TestResult(
+                        "All Assertion Types",
+                        false,
+                        "Assertion count mismatch",
+                        "Expected 4, got ${parsed.assertions.size}",
+                    )
+                }
+
+                // Check each type
+                val hasActions = parsed.assertions.any { it is AssertionDefinition.Actions }
+                val hasCreativeWork = parsed.assertions.any { it is AssertionDefinition.CreativeWork }
+                val hasTrainingMining = parsed.assertions.any { it is AssertionDefinition.TrainingMining }
+                val hasCustom = parsed.assertions.any { it is AssertionDefinition.Custom }
+
+                if (!hasActions || !hasCreativeWork || !hasTrainingMining || !hasCustom) {
+                    return@runTest TestResult(
+                        "All Assertion Types",
+                        false,
+                        "Missing assertion types after round-trip",
+                        "Actions: $hasActions, CreativeWork: $hasCreativeWork, " +
+                            "TrainingMining: $hasTrainingMining, Custom: $hasCustom",
+                    )
+                }
+
+                // Verify custom assertion data
+                val custom = parsed.assertions.filterIsInstance<AssertionDefinition.Custom>().first()
+                if (custom.label != "com.example.custom") {
+                    return@runTest TestResult(
+                        "All Assertion Types",
+                        false,
+                        "Custom label mismatch",
+                        "Expected 'com.example.custom', got '${custom.label}'",
+                    )
+                }
+
+                TestResult(
+                    "All Assertion Types",
+                    true,
+                    "All assertion types serialize correctly",
+                    "JSON length: ${jsonString.length}",
+                )
+            } catch (e: Exception) {
+                TestResult(
+                    "All Assertion Types",
+                    false,
+                    "Error: ${e.message}",
+                    e.stackTraceToString(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests ingredient handling with different relationships.
+     */
+    suspend fun testIngredients(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Ingredients") {
+            try {
+                val manifest = ManifestDefinition(
+                    title = "Composite Image",
+                    claimGeneratorInfo = listOf(ClaimGeneratorInfo(name = "test")),
+                    assertions = listOf(
+                        AssertionDefinition.actions(
+                            listOf(ActionAssertion(action = PredefinedAction.PLACED)),
+                        ),
+                    ),
+                    ingredients = listOf(
+                        Ingredient.parent(
+                            title = "Background Image",
+                            format = "image/jpeg",
+                        ),
+                        Ingredient.component(
+                            title = "Overlay Graphic",
+                            format = "image/png",
+                        ),
+                        Ingredient(
+                            title = "Full Ingredient",
+                            format = "image/jpeg",
+                            relationship = Relationship.PARENT_OF,
+                            description = "The original source image",
+                            documentId = "doc-12345",
+                            instanceId = "instance-67890",
+                            provenance = "https://example.com/provenance",
+                            validationStatus = listOf(
+                                ValidationStatus(code = ValidationStatusCode.CLAIM_SIGNATURE_VALIDATED),
+                            ),
+                        ),
+                    ),
+                )
+
+                val jsonString = manifest.toJson()
+                val parsed = ManifestDefinition.fromJson(jsonString)
+
+                if (parsed.ingredients.size != 3) {
+                    return@runTest TestResult(
+                        "Ingredients",
+                        false,
+                        "Ingredient count mismatch",
+                        "Expected 3, got ${parsed.ingredients.size}",
+                    )
+                }
+
+                // Verify relationships
+                val parent = parsed.ingredients.find { it.title == "Background Image" }
+                val component = parsed.ingredients.find { it.title == "Overlay Graphic" }
+                val full = parsed.ingredients.find { it.title == "Full Ingredient" }
+
+                if (parent?.relationship != Relationship.PARENT_OF) {
+                    return@runTest TestResult(
+                        "Ingredients",
+                        false,
+                        "Parent relationship incorrect",
+                        "Got: ${parent?.relationship}",
+                    )
+                }
+
+                if (component?.relationship != Relationship.COMPONENT_OF) {
+                    return@runTest TestResult(
+                        "Ingredients",
+                        false,
+                        "Component relationship incorrect",
+                        "Got: ${component?.relationship}",
+                    )
+                }
+
+                // Verify full ingredient fields
+                if (full?.documentId != "doc-12345" || full.instanceId != "instance-67890") {
+                    return@runTest TestResult(
+                        "Ingredients",
+                        false,
+                        "Full ingredient fields missing",
+                        "documentId: ${full?.documentId}, instanceId: ${full?.instanceId}",
+                    )
+                }
+
+                if (full?.validationStatus?.firstOrNull()?.code != ValidationStatusCode.CLAIM_SIGNATURE_VALIDATED) {
+                    return@runTest TestResult(
+                        "Ingredients",
+                        false,
+                        "Validation status not preserved",
+                    )
+                }
+
+                TestResult(
+                    "Ingredients",
+                    true,
+                    "Ingredients serialize correctly with all relationships",
+                )
+            } catch (e: Exception) {
+                TestResult(
+                    "Ingredients",
+                    false,
+                    "Error: ${e.message}",
+                    e.stackTraceToString(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests action assertions with regions of interest (changes).
+     */
+    suspend fun testActionWithRegions(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Action with Regions") {
+            try {
+                val manifest = ManifestDefinition(
+                    title = "Edited Image",
+                    claimGeneratorInfo = listOf(ClaimGeneratorInfo(name = "test")),
+                    assertions = listOf(
+                        AssertionDefinition.actions(
+                            listOf(
+                                ActionAssertion(
+                                    action = PredefinedAction.EDITED,
+                                    softwareAgent = "PhotoEditor 3.0",
+                                    reason = "Color correction applied",
+                                    changes = listOf(
+                                        RegionOfInterest(
+                                            region = listOf(
+                                                RegionRange(
+                                                    type = RangeType.SPATIAL,
+                                                    shape = Shape.rectangle(
+                                                        x = 10.0,
+                                                        y = 10.0,
+                                                        width = 80.0,
+                                                        height = 80.0,
+                                                        unit = UnitType.PERCENT,
+                                                    ),
+                                                ),
+                                            ),
+                                            imageRegionType = ImageRegionType.FACE,
+                                            description = "Face region was edited",
+                                        ),
+                                    ),
+                                ),
+                                ActionAssertion(
+                                    action = PredefinedAction.REMOVED,
+                                    reason = "Background removed",
+                                    changes = listOf(
+                                        RegionOfInterest(
+                                            region = listOf(
+                                                RegionRange(
+                                                    type = RangeType.SPATIAL,
+                                                    shape = Shape.polygon(
+                                                        vertices = listOf(
+                                                            Coordinate(0.0, 0.0),
+                                                            Coordinate(100.0, 0.0),
+                                                            Coordinate(100.0, 100.0),
+                                                            Coordinate(0.0, 100.0),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                )
+
+                val jsonString = manifest.toJson()
+                val parsed = ManifestDefinition.fromJson(jsonString)
+
+                val actions = (parsed.assertions.first() as AssertionDefinition.Actions).actions
+                if (actions.size != 2) {
+                    return@runTest TestResult(
+                        "Action with Regions",
+                        false,
+                        "Action count mismatch",
+                        "Expected 2, got ${actions.size}",
+                    )
+                }
+
+                // Verify first action's region
+                val editAction = actions.find { it.action == "c2pa.edited" }
+                val changes = editAction?.changes
+                if (changes.isNullOrEmpty()) {
+                    return@runTest TestResult(
+                        "Action with Regions",
+                        false,
+                        "Edit action has no changes",
+                    )
+                }
+
+                val region = changes.first().region?.first()
+                val shape = region?.shape
+                if (shape?.type != ShapeType.RECTANGLE) {
+                    return@runTest TestResult(
+                        "Action with Regions",
+                        false,
+                        "Shape type mismatch",
+                        "Expected RECTANGLE, got ${shape?.type}",
+                    )
+                }
+
+                if (shape.width != 80.0 || shape.height != 80.0) {
+                    return@runTest TestResult(
+                        "Action with Regions",
+                        false,
+                        "Shape dimensions incorrect",
+                        "width: ${shape.width}, height: ${shape.height}",
+                    )
+                }
+
+                // Verify polygon action
+                val removeAction = actions.find { it.action == "c2pa.removed" }
+                val polygonShape = removeAction?.changes?.first()?.region?.first()?.shape
+                if (polygonShape?.type != ShapeType.POLYGON) {
+                    return@runTest TestResult(
+                        "Action with Regions",
+                        false,
+                        "Polygon shape type mismatch",
+                        "Expected POLYGON, got ${polygonShape?.type}",
+                    )
+                }
+
+                if (polygonShape.vertices?.size != 4) {
+                    return@runTest TestResult(
+                        "Action with Regions",
+                        false,
+                        "Polygon vertex count incorrect",
+                        "Expected 4, got ${polygonShape.vertices?.size}",
+                    )
+                }
+
+                TestResult(
+                    "Action with Regions",
+                    true,
+                    "Actions with complex regions serialize correctly",
+                )
+            } catch (e: Exception) {
+                TestResult(
+                    "Action with Regions",
+                    false,
+                    "Error: ${e.message}",
+                    e.stackTraceToString(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests malformed JSON handling - ensures graceful error handling.
+     */
+    suspend fun testMalformedJson(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Malformed JSON") {
+            val testCases = listOf(
+                "" to "empty string",
+                "{" to "incomplete JSON",
+                "{\"title\": \"test\"}" to "missing claimGeneratorInfo",
+                "not json at all" to "invalid JSON syntax",
+                "{\"title\": null, \"claim_generator_info\": []}" to "null required field",
+            )
+
+            for ((json, description) in testCases) {
+                try {
+                    ManifestDefinition.fromJson(json)
+                    return@runTest TestResult(
+                        "Malformed JSON",
+                        false,
+                        "Should have thrown for: $description",
+                        "JSON: $json",
+                    )
+                } catch (e: Exception) {
+                    // Expected - continue to next test case
+                }
+            }
+
+            TestResult(
+                "Malformed JSON",
+                true,
+                "All malformed JSON cases throw exceptions",
+                "Tested ${testCases.size} cases",
+            )
+        }
+    }
+
+    /**
+     * Tests special characters in string fields survive serialization.
+     */
+    suspend fun testSpecialCharacters(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Special Characters") {
+            try {
+                val specialStrings = listOf(
+                    "Hello \"World\"", // Quotes
+                    "Line1\nLine2", // Newline
+                    "Tab\there", // Tab
+                    "Unicode: \u00E9\u00E8\u00EA", // Accented chars
+                    "Emoji: \uD83D\uDCF7", // Camera emoji
+                    "Path: C:\\Users\\test", // Backslashes
+                    "<script>alert('xss')</script>", // HTML-like
+                    "日本語テスト", // Japanese
+                )
+
+                for (special in specialStrings) {
+                    val manifest = ManifestDefinition(
+                        title = special,
+                        claimGeneratorInfo = listOf(
+                            ClaimGeneratorInfo(name = special),
+                        ),
+                    )
+
+                    val jsonString = manifest.toJson()
+                    val parsed = ManifestDefinition.fromJson(jsonString)
+
+                    if (parsed.title != special) {
+                        return@runTest TestResult(
+                            "Special Characters",
+                            false,
+                            "Title mismatch for special string",
+                            "Expected: $special, Got: ${parsed.title}",
+                        )
+                    }
+
+                    if (parsed.claimGeneratorInfo.first().name != special) {
+                        return@runTest TestResult(
+                            "Special Characters",
+                            false,
+                            "ClaimGeneratorInfo name mismatch",
+                            "Expected: $special, Got: ${parsed.claimGeneratorInfo.first().name}",
+                        )
+                    }
+                }
+
+                TestResult(
+                    "Special Characters",
+                    true,
+                    "All special characters serialize correctly",
+                    "Tested ${specialStrings.size} strings",
+                )
+            } catch (e: Exception) {
+                TestResult(
+                    "Special Characters",
+                    false,
+                    "Error: ${e.message}",
+                    e.stackTraceToString(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests the ManifestDefinition.created() convenience factory.
+     */
+    suspend fun testCreatedFactory(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Created Factory") {
+            try {
+                val manifest = ManifestDefinition.created(
+                    title = "New Photo",
+                    claimGeneratorInfo = ClaimGeneratorInfo(
+                        name = "Camera App",
+                        version = "2.0",
+                    ),
+                    digitalSourceType = DigitalSourceType.DIGITAL_CAPTURE,
+                )
+
+                if (manifest.title != "New Photo") {
+                    return@runTest TestResult(
+                        "Created Factory",
+                        false,
+                        "Title mismatch",
+                    )
+                }
+
+                if (manifest.assertions.size != 1) {
+                    return@runTest TestResult(
+                        "Created Factory",
+                        false,
+                        "Should have exactly 1 assertion",
+                    )
+                }
+
+                val assertion = manifest.assertions.first() as? AssertionDefinition.Actions
+                if (assertion == null) {
+                    return@runTest TestResult(
+                        "Created Factory",
+                        false,
+                        "Assertion is not Actions type",
+                    )
+                }
+
+                val action = assertion.actions.first()
+                if (action.action != "c2pa.created") {
+                    return@runTest TestResult(
+                        "Created Factory",
+                        false,
+                        "Action is not c2pa.created",
+                        "Got: ${action.action}",
+                    )
+                }
+
+                val expectedSourceType = "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCapture"
+                if (action.digitalSourceType != expectedSourceType) {
+                    return@runTest TestResult(
+                        "Created Factory",
+                        false,
+                        "Digital source type mismatch",
+                        "Expected: $expectedSourceType, Got: ${action.digitalSourceType}",
+                    )
+                }
+
+                // Verify it works with Builder
+                val jsonString = manifest.toJson()
+                val builder = Builder.fromJson(jsonString)
+                builder.close()
+
+                TestResult(
+                    "Created Factory",
+                    true,
+                    "ManifestDefinition.created() works correctly",
+                )
+            } catch (e: Exception) {
+                TestResult(
+                    "Created Factory",
+                    false,
+                    "Error: ${e.message}",
+                    e.stackTraceToString(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests all ValidationStatusCode values serialize correctly.
+     */
+    suspend fun testAllValidationStatusCodes(): TestResult = withContext(Dispatchers.IO) {
+        runTest("All Validation Status Codes") {
+            try {
+                val allCodes = ValidationStatusCode.entries
+
+                for (code in allCodes) {
+                    val status = ValidationStatus(code = code, explanation = "Test for $code")
+                    val ingredient = Ingredient(
+                        title = "Test",
+                        validationStatus = listOf(status),
+                    )
+
+                    val manifest = ManifestDefinition(
+                        title = "Status Test",
+                        claimGeneratorInfo = listOf(ClaimGeneratorInfo(name = "test")),
+                        ingredients = listOf(ingredient),
+                    )
+
+                    val jsonString = manifest.toJson()
+                    val parsed = ManifestDefinition.fromJson(jsonString)
+
+                    val parsedCode = parsed.ingredients.first().validationStatus?.first()?.code
+                    if (parsedCode != code) {
+                        return@runTest TestResult(
+                            "All Validation Status Codes",
+                            false,
+                            "Code mismatch for $code",
+                            "Got: $parsedCode",
+                        )
+                    }
+                }
+
+                TestResult(
+                    "All Validation Status Codes",
+                    true,
+                    "All ${allCodes.size} validation status codes serialize correctly",
+                )
+            } catch (e: Exception) {
+                TestResult(
+                    "All Validation Status Codes",
+                    false,
+                    "Error: ${e.message}",
+                    e.stackTraceToString(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Tests all DigitalSourceType values serialize correctly in actions.
+     */
+    suspend fun testAllDigitalSourceTypes(): TestResult = withContext(Dispatchers.IO) {
+        runTest("All Digital Source Types") {
+            try {
+                val allTypes = DigitalSourceType.entries
+
+                for (sourceType in allTypes) {
+                    val manifest = ManifestDefinition(
+                        title = "Source Type Test",
+                        claimGeneratorInfo = listOf(ClaimGeneratorInfo(name = "test")),
+                        assertions = listOf(
+                            AssertionDefinition.actions(
+                                listOf(ActionAssertion.created(sourceType)),
+                            ),
+                        ),
+                    )
+
+                    val jsonString = manifest.toJson()
+                    val parsed = ManifestDefinition.fromJson(jsonString)
+
+                    val actions = (parsed.assertions.first() as AssertionDefinition.Actions).actions
+                    val parsedSourceType = actions.first().digitalSourceType
+
+                    // Verify it's a valid IPTC URL
+                    if (parsedSourceType == null || !parsedSourceType.contains("digitalsourcetype")) {
+                        return@runTest TestResult(
+                            "All Digital Source Types",
+                            false,
+                            "Invalid source type URL for $sourceType",
+                            "Got: $parsedSourceType",
+                        )
+                    }
+                }
+
+                TestResult(
+                    "All Digital Source Types",
+                    true,
+                    "All ${allTypes.size} digital source types serialize correctly",
+                )
+            } catch (e: Exception) {
+                TestResult(
+                    "All Digital Source Types",
+                    false,
+                    "Error: ${e.message}",
+                    e.stackTraceToString(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Helper function to clone and compare a manifest via JSON.
+     */
+    private fun cloneAndCompare(manifest: ManifestDefinition, testName: String): TestResult {
+        return try {
+            val jsonString = manifest.toJson()
+            val m2 = ManifestDefinition.fromJson(jsonString)
+
+            if (manifest == m2) {
+                TestResult(
+                    testName,
+                    true,
+                    "Manifest rendered as expected",
+                    "JSON: ${jsonString.take(200)}${if (jsonString.length > 200) "..." else ""}",
+                )
+            } else {
+                TestResult(
+                    testName,
+                    false,
+                    "Broken compiled manifest",
+                    "Original: ${manifest.toJson()}\nDecoded: ${m2.toJson()}",
+                )
+            }
+        } catch (e: Exception) {
+            TestResult(
+                testName,
+                false,
+                "Error during clone and compare: ${e.message}",
+                e.stackTraceToString(),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Adds manifest-building capabilities to bring the library inline with the iOS library.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment