### PR TITLE
fix: Example app navigation overlap

### DIFF
--- a/example-app/app/src/main/kotlin/org/contentauth/c2pa/exampleapp/ui/camera/CameraScreen.kt
+++ b/example-app/app/src/main/kotlin/org/contentauth/c2pa/exampleapp/ui/camera/CameraScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -243,7 +244,7 @@ private fun CameraPreview(lifecycleOwner: LifecycleOwner, onCapture: (Bitmap) ->
                 }
             },
             modifier =
-            Modifier.align(Alignment.BottomCenter).padding(bottom = 100.dp).size(72.dp),
+            Modifier.align(Alignment.BottomCenter).navigationBarsPadding().padding(bottom = 100.dp).size(72.dp),
         ) {
             Icon(
                 imageVector = Icons.Filled.PhotoCamera,
@@ -332,6 +333,7 @@ private fun CameraControls(
         modifier =
         modifier.fillMaxWidth()
             .background(Color.Black.copy(alpha = 0.5f))
+            .navigationBarsPadding()
             .padding(16.dp),
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically,
@@ -406,6 +408,7 @@ private fun ImagePreview(bitmap: Bitmap, location: Location?, onConfirm: () -> U
             Modifier.align(Alignment.BottomCenter)
                 .fillMaxWidth()
                 .background(Color.Black.copy(alpha = 0.7f))
+                .navigationBarsPadding()
                 .padding(16.dp),
             horizontalArrangement = Arrangement.SpaceEvenly,
         ) {


### PR DESCRIPTION
## Changes in this pull request
<!-- Give a description of what has changed -->
For users who use navigation buttons on Android instead of gestures, the navigation bar in the Example app is set behind the system navigation and inaccessible.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment