### PR TITLE
Feat: CAWG callback signing

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -229,6 +229,7 @@ tasks.register("setupDirectories") {
 
 tasks.register("downloadNativeLibraries") {
     dependsOn("setupDirectories")
+    mustRunAfter("cleanDownloadedLibraries")
 
     val projectDir = layout.projectDirectory
     val downloadDir = rootDir.resolve("downloads")

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -242,6 +242,20 @@ tasks.register("downloadNativeLibraries") {
         println("Using C2PA version: $version")
         downloadDir.mkdirs()
 
+        // The existence checks below reuse whatever was downloaded previously, so a
+        // c2paVersion bump must explicitly invalidate stale artifacts.
+        val versionStamp = downloadDir.resolve("c2pa-version.txt")
+        if (versionStamp.takeIf { it.exists() }?.readText()?.trim() != version) {
+            println("C2PA version changed, removing previously downloaded libraries")
+            archMap.keys.forEach { arch ->
+                jniLibsDir.file("$arch/libc2pa_c.so").asFile.delete()
+                downloadDir.resolve("$arch.zip").delete()
+                downloadDir.resolve(arch).deleteRecursively()
+            }
+            destHeader.asFile.delete()
+            versionStamp.writeText(version)
+        }
+
         var headerDownloaded = false
 
         archMap.forEach { (arch, target) ->

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -1,3 +1,3 @@
 # C2PA Native Library Version
 # Update this to use a different release from https://github.com/contentauth/c2pa-rs/releases
-c2paVersion=v0.85.0
+c2paVersion=v0.85.2

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -1,3 +1,3 @@
 # C2PA Native Library Version
 # Update this to use a different release from https://github.com/contentauth/c2pa-rs/releases
-c2paVersion=v0.84.1
+c2paVersion=v0.85.0

--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidSignerTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidSignerTests.kt
@@ -142,6 +142,12 @@ class AndroidSignerTests : SignerTests() {
     }
 
     @Test
+    fun runTestCawgRejectsInvalidInputs() = runBlocking {
+        val result = testCawgRejectsInvalidInputs()
+        assertTrue(result.success, "CAWG Combined Signer Rejects Invalid Inputs test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestCawgCombinedStrongBoxIdentity() = runBlocking {
         val result = testCawgCombinedStrongBoxIdentity()
         assertTrue(result.success, "CAWG Combined Signer (StrongBox Identity) test failed: ${result.message}")

--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidSignerTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidSignerTests.kt
@@ -116,4 +116,34 @@ class AndroidSignerTests : SignerTests() {
         val result = testSignerFromSettingsJson()
         assertTrue(result.success, "Signer From Settings (JSON) test failed: ${result.message}")
     }
+
+    @Test
+    fun runTestCawgCombinedPemSigner() = runBlocking {
+        val result = testCawgCombinedPemSigner()
+        assertTrue(result.success, "CAWG Combined Signer (PEM + PEM) test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestCawgCombinedCallbackSigner() = runBlocking {
+        val result = testCawgCombinedCallbackSigner()
+        assertTrue(result.success, "CAWG Combined Signer (Callback + Callback) test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestCawgConsumesInputSigners() = runBlocking {
+        val result = testCawgConsumesInputSigners()
+        assertTrue(result.success, "CAWG Combined Signer Consumes Inputs test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestCawgRejectsClosedSigner() = runBlocking {
+        val result = testCawgRejectsClosedSigner()
+        assertTrue(result.success, "CAWG Combined Signer Rejects Closed Input test failed: ${result.message}")
+    }
+
+    @Test
+    fun runTestCawgCombinedStrongBoxIdentity() = runBlocking {
+        val result = testCawgCombinedStrongBoxIdentity()
+        assertTrue(result.success, "CAWG Combined Signer (StrongBox Identity) test failed: ${result.message}")
+    }
 }

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -1178,6 +1178,111 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromCallback(JNIE
     return (jlong)(uintptr_t)signer;
 }
 
+// Helper to convert a String[] into a NULL-terminated C string array for the FFI
+static int build_cstring_array(JNIEnv *env, jobjectArray jarray, const char ***out_array, jstring **out_jstrings, jsize *out_len) {
+    if (jarray == NULL) {
+        const char **arr = (const char **)malloc(sizeof(const char *));
+        if (arr == NULL) return -1;
+        arr[0] = NULL;
+        *out_array = arr;
+        *out_jstrings = NULL;
+        *out_len = 0;
+        return 0;
+    }
+    jsize len = (*env)->GetArrayLength(env, jarray);
+    const char **arr = (const char **)malloc(sizeof(const char *) * (size_t)(len + 1));
+    if (arr == NULL) return -1;
+    jstring *jstrs = NULL;
+    if (len > 0) {
+        jstrs = (jstring *)malloc(sizeof(jstring) * (size_t)len);
+        if (jstrs == NULL) {
+            free(arr);
+            return -1;
+        }
+    }
+    for (jsize i = 0; i < len; i++) {
+        jstring js = (jstring)(*env)->GetObjectArrayElement(env, jarray, i);
+        if (js == NULL) {
+            for (jsize j = 0; j < i; j++) {
+                (*env)->ReleaseStringUTFChars(env, jstrs[j], arr[j]);
+                (*env)->DeleteLocalRef(env, jstrs[j]);
+            }
+            free(jstrs);
+            free(arr);
+            (*env)->ThrowNew(env,
+                             (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                             "Array element cannot be null");
+            return -1;
+        }
+        const char *cs = (*env)->GetStringUTFChars(env, js, NULL);
+        if (cs == NULL) {
+            (*env)->DeleteLocalRef(env, js);
+            for (jsize j = 0; j < i; j++) {
+                (*env)->ReleaseStringUTFChars(env, jstrs[j], arr[j]);
+                (*env)->DeleteLocalRef(env, jstrs[j]);
+            }
+            free(jstrs);
+            free(arr);
+            return -1;
+        }
+        jstrs[i] = js;
+        arr[i] = cs;
+    }
+    arr[len] = NULL;
+    *out_array = arr;
+    *out_jstrings = jstrs;
+    *out_len = len;
+    return 0;
+}
+
+// Helper to release the C string array allocated by build_cstring_array
+static void release_cstring_array(JNIEnv *env, const char **arr, jstring *jstrs, jsize len) {
+    if (jstrs != NULL) {
+        for (jsize i = 0; i < len; i++) {
+            if (jstrs[i] != NULL && arr != NULL && arr[i] != NULL) {
+                (*env)->ReleaseStringUTFChars(env, jstrs[i], arr[i]);
+                (*env)->DeleteLocalRef(env, jstrs[i]);
+            }
+        }
+        free(jstrs);
+    }
+    if (arr != NULL) free((void *)arr);
+}
+
+JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeCombineCawg(JNIEnv *env, jclass clazz, jlong c2paHandle, jlong identityHandle, jobjectArray referencedAssertions, jobjectArray roles) {
+    if (c2paHandle == 0 || identityHandle == 0) {
+        (*env)->ThrowNew(env,
+                         (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "Signer handles cannot be zero");
+        return 0;
+    }
+
+    const char **refs_arr = NULL;
+    jstring *refs_jstrs = NULL;
+    jsize refs_len = 0;
+    if (build_cstring_array(env, referencedAssertions, &refs_arr, &refs_jstrs,
+                            &refs_len) != 0) {
+        return 0;
+    }
+
+    const char **roles_arr = NULL;
+    jstring *roles_jstrs = NULL;
+    jsize roles_len = 0;
+    if (build_cstring_array(env, roles, &roles_arr, &roles_jstrs, &roles_len) != 0) {
+        release_cstring_array(env, refs_arr, refs_jstrs, refs_len);
+        return 0;
+    }
+
+    struct C2paSigner *combined = c2pa_identity_signer_create(
+        (struct C2paSigner *)(uintptr_t)c2paHandle,
+        (struct C2paSigner *)(uintptr_t)identityHandle, refs_arr, roles_arr);
+
+    release_cstring_array(env, refs_arr, refs_jstrs, refs_len);
+    release_cstring_array(env, roles_arr, roles_jstrs, roles_len);
+
+    return (jlong)(uintptr_t)combined;
+}
+
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_reserveSizeNative(JNIEnv *env, jobject obj, jlong signerPtr) {
     return c2pa_signer_reserve_size((struct C2paSigner*)(uintptr_t)signerPtr);
 }

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -1060,34 +1060,53 @@ static void register_signer_context(struct C2paSigner *signer, JavaSignerContext
     }
 }
 
-// Unregister and free a signer context
+// Unregister and free all signer contexts associated with a signer
+// (a CAWG combined signer may carry more than one after rekey_signer_context).
 static void unregister_signer_context(struct C2paSigner *signer) {
     pthread_mutex_lock(&g_signerContextsMutex);
-    
+
     SignerContextNode **current = &g_signerContexts;
     while (*current != NULL) {
         if ((*current)->signer == signer) {
             SignerContextNode *toDelete = *current;
             JavaSignerContext *ctx = toDelete->context;
-            
+
             // Mark context as inactive
             if (ctx != NULL) {
                 ctx->isActive = JNI_FALSE;
-                
+
                 JNIEnv *env = get_jni_env();
                 if (env != NULL && ctx->callback != NULL) {
                     (*env)->DeleteGlobalRef(env, ctx->callback);
                 }
                 free(ctx);
             }
-            
+
             *current = toDelete->next;
             free(toDelete);
-            break;
+            // Continue scanning — do not break, so all matches are removed.
+        } else {
+            current = &(*current)->next;
         }
-        current = &(*current)->next;
     }
-    
+
+    pthread_mutex_unlock(&g_signerContextsMutex);
+}
+
+// Re-key signer contexts after c2pa_identity_signer_create consumes the input signers,
+// so the contexts are freed when the combined signer is freed.
+static void rekey_signer_context(struct C2paSigner *old_signer, struct C2paSigner *new_signer) {
+    if (old_signer == new_signer) {
+        return;
+    }
+    pthread_mutex_lock(&g_signerContextsMutex);
+    SignerContextNode *current = g_signerContexts;
+    while (current != NULL) {
+        if (current->signer == old_signer) {
+            current->signer = new_signer;
+        }
+        current = current->next;
+    }
     pthread_mutex_unlock(&g_signerContextsMutex);
 }
 
@@ -1178,27 +1197,33 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromCallback(JNIE
     return (jlong)(uintptr_t)signer;
 }
 
-// Helper to convert a String[] into a NULL-terminated C string array for the FFI
+// Convert a String[] into a NULL-terminated C string array for the FFI.
+// An empty or NULL input maps to NULL out_array (the FFI's "no entries" sentinel).
 static int build_cstring_array(JNIEnv *env, jobjectArray jarray, const char ***out_array, jstring **out_jstrings, jsize *out_len) {
+    *out_array = NULL;
+    *out_jstrings = NULL;
+    *out_len = 0;
     if (jarray == NULL) {
-        const char **arr = (const char **)malloc(sizeof(const char *));
-        if (arr == NULL) return -1;
-        arr[0] = NULL;
-        *out_array = arr;
-        *out_jstrings = NULL;
-        *out_len = 0;
         return 0;
     }
     jsize len = (*env)->GetArrayLength(env, jarray);
+    if (len == 0) {
+        return 0;
+    }
     const char **arr = (const char **)malloc(sizeof(const char *) * (size_t)(len + 1));
-    if (arr == NULL) return -1;
-    jstring *jstrs = NULL;
-    if (len > 0) {
-        jstrs = (jstring *)malloc(sizeof(jstring) * (size_t)len);
-        if (jstrs == NULL) {
-            free(arr);
-            return -1;
-        }
+    if (arr == NULL) {
+        (*env)->ThrowNew(env,
+                         (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
+                         "Failed to allocate string array");
+        return -1;
+    }
+    jstring *jstrs = (jstring *)malloc(sizeof(jstring) * (size_t)len);
+    if (jstrs == NULL) {
+        free(arr);
+        (*env)->ThrowNew(env,
+                         (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
+                         "Failed to allocate string array");
+        return -1;
     }
     for (jsize i = 0; i < len; i++) {
         jstring js = (jstring)(*env)->GetObjectArrayElement(env, jarray, i);
@@ -1273,12 +1298,19 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeCombineCawg(JNIEn
         return 0;
     }
 
+    struct C2paSigner *c2pa_signer = (struct C2paSigner *)(uintptr_t)c2paHandle;
+    struct C2paSigner *identity_signer = (struct C2paSigner *)(uintptr_t)identityHandle;
     struct C2paSigner *combined = c2pa_identity_signer_create(
-        (struct C2paSigner *)(uintptr_t)c2paHandle,
-        (struct C2paSigner *)(uintptr_t)identityHandle, refs_arr, roles_arr);
+        c2pa_signer, identity_signer, refs_arr, roles_arr);
 
     release_cstring_array(env, refs_arr, refs_jstrs, refs_len);
     release_cstring_array(env, roles_arr, roles_jstrs, roles_len);
+
+    if (combined != NULL) {
+        // Re-key input contexts so callback signers' global refs are freed with the combined signer.
+        rekey_signer_context(c2pa_signer, combined);
+        rekey_signer_context(identity_signer, combined);
+    }
 
     return (jlong)(uintptr_t)combined;
 }

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -1061,7 +1061,7 @@ static void register_signer_context(struct C2paSigner *signer, JavaSignerContext
 }
 
 // Unregister and free all signer contexts associated with a signer
-// (a CAWG combined signer may carry more than one after rekey_signer_context).
+// (a CAWG combined signer may carry more than one after attach_signer_contexts).
 static void unregister_signer_context(struct C2paSigner *signer) {
     pthread_mutex_lock(&g_signerContextsMutex);
 
@@ -1093,21 +1093,62 @@ static void unregister_signer_context(struct C2paSigner *signer) {
     pthread_mutex_unlock(&g_signerContextsMutex);
 }
 
-// Re-key signer contexts after c2pa_identity_signer_create consumes the input signers,
-// so the contexts are freed when the combined signer is freed.
-static void rekey_signer_context(struct C2paSigner *old_signer, struct C2paSigner *new_signer) {
-    if (old_signer == new_signer) {
+// Detach all context nodes keyed by a signer from the registry and return them
+// as a chain. Called BEFORE c2pa_identity_signer_create, which frees the input
+// signer allocations even on failure: their addresses must not remain registry
+// keys, or a concurrent signer allocated at a recycled address would alias them.
+static SignerContextNode *detach_signer_contexts(struct C2paSigner *signer) {
+    SignerContextNode *detached = NULL;
+
+    pthread_mutex_lock(&g_signerContextsMutex);
+    SignerContextNode **current = &g_signerContexts;
+    while (*current != NULL) {
+        if ((*current)->signer == signer) {
+            SignerContextNode *node = *current;
+            *current = node->next;
+            node->next = detached;
+            detached = node;
+        } else {
+            current = &(*current)->next;
+        }
+    }
+    pthread_mutex_unlock(&g_signerContextsMutex);
+
+    return detached;
+}
+
+// Re-insert detached context nodes keyed to the combined signer that now owns
+// the consumed inputs' callbacks, so they are freed when it is freed.
+static void attach_signer_contexts(SignerContextNode *nodes, struct C2paSigner *signer) {
+    if (nodes == NULL) {
         return;
     }
     pthread_mutex_lock(&g_signerContextsMutex);
-    SignerContextNode *current = g_signerContexts;
-    while (current != NULL) {
-        if (current->signer == old_signer) {
-            current->signer = new_signer;
-        }
-        current = current->next;
+    while (nodes != NULL) {
+        SignerContextNode *next = nodes->next;
+        nodes->signer = signer;
+        nodes->next = g_signerContexts;
+        g_signerContexts = nodes;
+        nodes = next;
     }
     pthread_mutex_unlock(&g_signerContextsMutex);
+}
+
+// Free detached context nodes whose signers were consumed by a failed combine.
+static void free_detached_contexts(JNIEnv *env, SignerContextNode *nodes) {
+    while (nodes != NULL) {
+        SignerContextNode *next = nodes->next;
+        JavaSignerContext *ctx = nodes->context;
+        if (ctx != NULL) {
+            ctx->isActive = JNI_FALSE;
+            if (env != NULL && ctx->callback != NULL) {
+                (*env)->DeleteGlobalRef(env, ctx->callback);
+            }
+            free(ctx);
+        }
+        free(nodes);
+        nodes = next;
+    }
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromCallback(JNIEnv *env, jclass clazz, jstring algorithm, jstring certificateChain, jstring tsaURL, jobject callback) {
@@ -1197,11 +1238,26 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromCallback(JNIE
     return (jlong)(uintptr_t)signer;
 }
 
-// Convert a String[] into a NULL-terminated C string array for the FFI.
-// An empty or NULL input maps to NULL out_array (the FFI's "no entries" sentinel).
-static int build_cstring_array(JNIEnv *env, jobjectArray jarray, const char ***out_array, jstring **out_jstrings, jsize *out_len) {
+// Free the C string array allocated by build_cstring_array. Safe on partially
+// built arrays (calloc'd, so unset entries are NULL).
+static void release_cstring_array(const char **arr, jsize len) {
+    if (arr == NULL) {
+        return;
+    }
+    for (jsize i = 0; i < len; i++) {
+        free((void *)arr[i]);
+    }
+    free((void *)arr);
+}
+
+// Convert a String[] into a NULL-terminated array of malloc'd C strings for the
+// FFI. Each element is copied and its JNI references released immediately, so no
+// local references are held across the FFI call (two near-limit arrays would
+// otherwise exceed ART's local reference budget). An empty or NULL input maps to
+// NULL out_array (the FFI's "no entries" sentinel). Returns 0 on success; on
+// failure throws a Java exception and returns -1.
+static int build_cstring_array(JNIEnv *env, jobjectArray jarray, const char ***out_array, jsize *out_len) {
     *out_array = NULL;
-    *out_jstrings = NULL;
     *out_len = 0;
     if (jarray == NULL) {
         return 0;
@@ -1210,16 +1266,8 @@ static int build_cstring_array(JNIEnv *env, jobjectArray jarray, const char ***o
     if (len == 0) {
         return 0;
     }
-    const char **arr = (const char **)malloc(sizeof(const char *) * (size_t)(len + 1));
+    const char **arr = (const char **)calloc((size_t)len + 1, sizeof(const char *));
     if (arr == NULL) {
-        (*env)->ThrowNew(env,
-                         (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
-                         "Failed to allocate string array");
-        return -1;
-    }
-    jstring *jstrs = (jstring *)malloc(sizeof(jstring) * (size_t)len);
-    if (jstrs == NULL) {
-        free(arr);
         (*env)->ThrowNew(env,
                          (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
                          "Failed to allocate string array");
@@ -1228,50 +1276,28 @@ static int build_cstring_array(JNIEnv *env, jobjectArray jarray, const char ***o
     for (jsize i = 0; i < len; i++) {
         jstring js = (jstring)(*env)->GetObjectArrayElement(env, jarray, i);
         if (js == NULL) {
-            for (jsize j = 0; j < i; j++) {
-                (*env)->ReleaseStringUTFChars(env, jstrs[j], arr[j]);
-                (*env)->DeleteLocalRef(env, jstrs[j]);
-            }
-            free(jstrs);
-            free(arr);
+            release_cstring_array(arr, len);
             (*env)->ThrowNew(env,
                              (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
                              "Array element cannot be null");
             return -1;
         }
-        const char *cs = (*env)->GetStringUTFChars(env, js, NULL);
-        if (cs == NULL) {
-            (*env)->DeleteLocalRef(env, js);
-            for (jsize j = 0; j < i; j++) {
-                (*env)->ReleaseStringUTFChars(env, jstrs[j], arr[j]);
-                (*env)->DeleteLocalRef(env, jstrs[j]);
-            }
-            free(jstrs);
-            free(arr);
+        const char *cs = jstring_to_cstring(env, js);
+        char *copy = cs != NULL ? strdup(cs) : NULL;
+        release_cstring(env, js, cs);
+        (*env)->DeleteLocalRef(env, js);
+        if (copy == NULL) {
+            release_cstring_array(arr, len);
+            (*env)->ThrowNew(env,
+                             (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
+                             "Failed to copy array element");
             return -1;
         }
-        jstrs[i] = js;
-        arr[i] = cs;
+        arr[i] = copy;
     }
-    arr[len] = NULL;
     *out_array = arr;
-    *out_jstrings = jstrs;
     *out_len = len;
     return 0;
-}
-
-// Helper to release the C string array allocated by build_cstring_array
-static void release_cstring_array(JNIEnv *env, const char **arr, jstring *jstrs, jsize len) {
-    if (jstrs != NULL) {
-        for (jsize i = 0; i < len; i++) {
-            if (jstrs[i] != NULL && arr != NULL && arr[i] != NULL) {
-                (*env)->ReleaseStringUTFChars(env, jstrs[i], arr[i]);
-                (*env)->DeleteLocalRef(env, jstrs[i]);
-            }
-        }
-        free(jstrs);
-    }
-    if (arr != NULL) free((void *)arr);
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeCombineCawg(JNIEnv *env, jclass clazz, jlong c2paHandle, jlong identityHandle, jobjectArray referencedAssertions, jobjectArray roles) {
@@ -1281,35 +1307,48 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeCombineCawg(JNIEn
                          "Signer handles cannot be zero");
         return 0;
     }
+    if (c2paHandle == identityHandle) {
+        // The FFI consumes each input; aliasing the same signer would untrack it
+        // without freeing, leaking it irrecoverably.
+        (*env)->ThrowNew(env,
+                         (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
+                         "c2pa and identity signers must be distinct");
+        return 0;
+    }
 
     const char **refs_arr = NULL;
-    jstring *refs_jstrs = NULL;
     jsize refs_len = 0;
-    if (build_cstring_array(env, referencedAssertions, &refs_arr, &refs_jstrs,
-                            &refs_len) != 0) {
+    if (build_cstring_array(env, referencedAssertions, &refs_arr, &refs_len) != 0) {
         return 0;
     }
 
     const char **roles_arr = NULL;
-    jstring *roles_jstrs = NULL;
     jsize roles_len = 0;
-    if (build_cstring_array(env, roles, &roles_arr, &roles_jstrs, &roles_len) != 0) {
-        release_cstring_array(env, refs_arr, refs_jstrs, refs_len);
+    if (build_cstring_array(env, roles, &roles_arr, &roles_len) != 0) {
+        release_cstring_array(refs_arr, refs_len);
         return 0;
     }
 
     struct C2paSigner *c2pa_signer = (struct C2paSigner *)(uintptr_t)c2paHandle;
     struct C2paSigner *identity_signer = (struct C2paSigner *)(uintptr_t)identityHandle;
+
+    SignerContextNode *c2pa_contexts = detach_signer_contexts(c2pa_signer);
+    SignerContextNode *identity_contexts = detach_signer_contexts(identity_signer);
+
     struct C2paSigner *combined = c2pa_identity_signer_create(
         c2pa_signer, identity_signer, refs_arr, roles_arr);
 
-    release_cstring_array(env, refs_arr, refs_jstrs, refs_len);
-    release_cstring_array(env, roles_arr, roles_jstrs, roles_len);
+    release_cstring_array(refs_arr, refs_len);
+    release_cstring_array(roles_arr, roles_len);
 
     if (combined != NULL) {
         // Re-key input contexts so callback signers' global refs are freed with the combined signer.
-        rekey_signer_context(c2pa_signer, combined);
-        rekey_signer_context(identity_signer, combined);
+        attach_signer_contexts(c2pa_contexts, combined);
+        attach_signer_contexts(identity_contexts, combined);
+    } else {
+        // The FFI consumed and freed the inputs even on failure; their contexts are dead.
+        free_detached_contexts(env, c2pa_contexts);
+        free_detached_contexts(env, identity_contexts);
     }
 
     return (jlong)(uintptr_t)combined;

--- a/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
@@ -28,6 +28,12 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
         }
 
         /**
+         * Per-array entry limit for FFI string array parameters. Mirrors
+         * `MAX_STRING_ARRAY_LEN` in `c2pa.h`.
+         */
+        private const val MAX_STRING_ARRAY_LEN = 256
+
+        /**
          * Creates a signer from PEM-encoded certificates and a private key.
          *
          * This is the simplest way to create a signer when you have the certificate chain
@@ -110,8 +116,7 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
          */
         @JvmStatic
         @Throws(C2PAError::class)
-        fun fromSettingsJson(settingsJson: String): Signer =
-            fromSettings(settingsJson, "json")
+        fun fromSettingsJson(settingsJson: String): Signer = fromSettings(settingsJson, "json")
 
         /**
          * Creates a signer from TOML settings configuration.
@@ -156,8 +161,7 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
          */
         @JvmStatic
         @Throws(C2PAError::class)
-        fun fromSettingsToml(settingsToml: String): Signer =
-            fromSettings(settingsToml, "toml")
+        fun fromSettingsToml(settingsToml: String): Signer = fromSettings(settingsToml, "toml")
 
         /**
          * Creates a signer from settings configuration in the specified format.
@@ -247,21 +251,33 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
          * [StrongBoxSigner] / [KeyStoreSigner] / [WebServiceSigner]. The combined
          * signer is then passed to [Builder.sign] like any other signer.
          *
-         * Ownership: both input signers are *consumed* by this call. After it
-         * returns (success or failure), neither may be used again. The wrapper
-         * zeros each input's internal pointer, so calling `close()` on the inputs
-         * (or wrapping them in a `use { }` block) is a safe no-op. Only the
-         * returned [Signer] must be closed by the caller.
+         * Ownership: once the underlying FFI call is reached, both input signers
+         * are *consumed* — ownership transfers to the returned signer and neither
+         * input may be used again. The wrapper zeros each input's internal pointer
+         * on consumption, so calling `close()` on the inputs (or wrapping them in
+         * a `use { }` block) is a safe no-op. Only the returned [Signer] must be
+         * closed by the caller. If this method throws *before* the FFI call (e.g.
+         * an input was already closed, or an argument failed validation), the
+         * inputs are NOT consumed and the caller remains responsible for closing
+         * them.
+         *
+         * Thread safety: this method reads each input's internal pointer without
+         * synchronization. Do not call it concurrently with [close] on the same
+         * signer, or with another operation that may free the underlying native
+         * pointer.
          *
          * @param c2pa The signer that produces the C2PA claim signature.
          * @param identity The signer that produces the CAWG identity assertion.
          * @param referencedAssertions Manifest assertion labels covered by the
-         *   identity assertion (e.g. `"c2pa.actions"`). Must be non-empty entries.
+         *   identity assertion (e.g. `"c2pa.actions"`). Each entry must be
+         *   non-empty; the list itself may have up to 256 entries.
          * @param roles Optional role strings to attach to the identity assertion.
+         *   Each entry must be non-empty; the list itself may have up to 256
+         *   entries.
          * @return A combined [Signer] suitable for passing to [Builder.sign].
          * @throws C2PAError.Api if either input signer is already closed, if
-         *   `referencedAssertions.size + roles.size` exceeds 256, if any entry
-         *   is empty, or if the underlying FFI call fails.
+         *   either list exceeds 256 entries, if any entry is empty, or if the
+         *   underlying FFI call fails.
          * @see Builder.sign
          */
         @JvmStatic
@@ -274,8 +290,13 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
         ): Signer {
             if (c2pa.ptr == 0L) throw C2PAError.Api("c2pa signer is already closed")
             if (identity.ptr == 0L) throw C2PAError.Api("identity signer is already closed")
-            if (referencedAssertions.size + roles.size > 256) {
-                throw C2PAError.Api("referencedAssertions + roles cannot exceed 256 entries")
+            if (referencedAssertions.size > MAX_STRING_ARRAY_LEN) {
+                throw C2PAError.Api(
+                    "referencedAssertions cannot exceed $MAX_STRING_ARRAY_LEN entries",
+                )
+            }
+            if (roles.size > MAX_STRING_ARRAY_LEN) {
+                throw C2PAError.Api("roles cannot exceed $MAX_STRING_ARRAY_LEN entries")
             }
             if (referencedAssertions.any { it.isEmpty() }) {
                 throw C2PAError.Api("referencedAssertions cannot contain empty strings")

--- a/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
@@ -237,6 +237,67 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
             if (handle == 0L) null else Signer(handle)
         }
 
+        /**
+         * Combine a C2PA claim signer with an X.509 identity signer to produce a
+         * combined signer that emits a `cawg.identity` assertion alongside the C2PA
+         * claim signature.
+         *
+         * Both input signers may be created via any existing factory: [fromKeys],
+         * [fromInfo], [withCallback], or hardware-backed factories such as
+         * [StrongBoxSigner] / [KeyStoreSigner] / [WebServiceSigner]. The combined
+         * signer is then passed to [Builder.sign] like any other signer.
+         *
+         * Ownership: both input signers are *consumed* by this call. After it
+         * returns (success or failure), neither may be used again. The wrapper
+         * zeros each input's internal pointer, so calling `close()` on the inputs
+         * (or wrapping them in a `use { }` block) is a safe no-op. Only the
+         * returned [Signer] must be closed by the caller.
+         *
+         * @param c2pa The signer that produces the C2PA claim signature.
+         * @param identity The signer that produces the CAWG identity assertion.
+         * @param referencedAssertions Manifest assertion labels covered by the
+         *   identity assertion (e.g. `"c2pa.actions"`). Must be non-empty entries.
+         * @param roles Optional role strings to attach to the identity assertion.
+         * @return A combined [Signer] suitable for passing to [Builder.sign].
+         * @throws C2PAError.Api if either input signer is already closed, if
+         *   `referencedAssertions.size + roles.size` exceeds 256, if any entry
+         *   is empty, or if the underlying FFI call fails.
+         * @see Builder.sign
+         */
+        @JvmStatic
+        @Throws(C2PAError::class)
+        fun withCawgIdentity(
+            c2pa: Signer,
+            identity: Signer,
+            referencedAssertions: List<String>,
+            roles: List<String> = emptyList(),
+        ): Signer {
+            if (c2pa.ptr == 0L) throw C2PAError.Api("c2pa signer is already closed")
+            if (identity.ptr == 0L) throw C2PAError.Api("identity signer is already closed")
+            if (referencedAssertions.size + roles.size > 256) {
+                throw C2PAError.Api("referencedAssertions + roles cannot exceed 256 entries")
+            }
+            if (referencedAssertions.any { it.isEmpty() }) {
+                throw C2PAError.Api("referencedAssertions cannot contain empty strings")
+            }
+            if (roles.any { it.isEmpty() }) {
+                throw C2PAError.Api("roles cannot contain empty strings")
+            }
+
+            return executeC2PAOperation("Failed to combine signers for CAWG identity") {
+                val handle =
+                    nativeCombineCawg(
+                        c2pa.ptr,
+                        identity.ptr,
+                        referencedAssertions.toTypedArray(),
+                        roles.toTypedArray(),
+                    )
+                c2pa.ptr = 0L
+                identity.ptr = 0L
+                if (handle == 0L) null else Signer(handle)
+            }
+        }
+
         @JvmStatic
         private external fun nativeFromInfo(
             algorithm: String,
@@ -255,6 +316,14 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
 
         @JvmStatic
         private external fun nativeFromSettings(): Long
+
+        @JvmStatic
+        private external fun nativeCombineCawg(
+            c2paHandle: Long,
+            identityHandle: Long,
+            referencedAssertions: Array<String>,
+            roles: Array<String>,
+        ): Long
     }
 
     /** Get the reserve size for this signer */

--- a/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
@@ -28,8 +28,10 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
         }
 
         /**
-         * Per-array entry limit for FFI string array parameters. Mirrors
-         * `MAX_STRING_ARRAY_LEN` in `c2pa.h`.
+         * Per-array slot limit for FFI string array parameters. Mirrors
+         * `MAX_STRING_ARRAY_LEN` in `c2pa.h`. The FFI requires the NULL
+         * terminator to fit within this limit, so each array may carry at most
+         * `MAX_STRING_ARRAY_LEN - 1` entries.
          */
         private const val MAX_STRING_ARRAY_LEN = 256
 
@@ -266,18 +268,19 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
          * signer, or with another operation that may free the underlying native
          * pointer.
          *
-         * @param c2pa The signer that produces the C2PA claim signature.
+         * @param c2pa The signer that produces the C2PA claim signature. Must
+         *   not be the same instance as [identity] (each input is consumed
+         *   separately).
          * @param identity The signer that produces the CAWG identity assertion.
          * @param referencedAssertions Manifest assertion labels covered by the
-         *   identity assertion (e.g. `"c2pa.actions"`). Each entry must be
-         *   non-empty; the list itself may have up to 256 entries.
+         *   identity assertion (e.g. `"c2pa.actions"`). The list may have up to
+         *   255 entries.
          * @param roles Optional role strings to attach to the identity assertion.
-         *   Each entry must be non-empty; the list itself may have up to 256
-         *   entries.
+         *   The list may have up to 255 entries.
          * @return A combined [Signer] suitable for passing to [Builder.sign].
-         * @throws C2PAError.Api if either input signer is already closed, if
-         *   either list exceeds 256 entries, if any entry is empty, or if the
-         *   underlying FFI call fails.
+         * @throws C2PAError.Api if the two inputs are the same instance, if
+         *   either input signer is already closed, if either list exceeds 255
+         *   entries, or if the underlying FFI call fails.
          * @see Builder.sign
          */
         @JvmStatic
@@ -288,21 +291,18 @@ class Signer internal constructor(internal var ptr: Long) : Closeable {
             referencedAssertions: List<String>,
             roles: List<String> = emptyList(),
         ): Signer {
+            if (c2pa === identity) {
+                throw C2PAError.Api("c2pa and identity signers must be distinct instances")
+            }
             if (c2pa.ptr == 0L) throw C2PAError.Api("c2pa signer is already closed")
             if (identity.ptr == 0L) throw C2PAError.Api("identity signer is already closed")
-            if (referencedAssertions.size > MAX_STRING_ARRAY_LEN) {
+            if (referencedAssertions.size >= MAX_STRING_ARRAY_LEN) {
                 throw C2PAError.Api(
-                    "referencedAssertions cannot exceed $MAX_STRING_ARRAY_LEN entries",
+                    "referencedAssertions cannot exceed ${MAX_STRING_ARRAY_LEN - 1} entries",
                 )
             }
-            if (roles.size > MAX_STRING_ARRAY_LEN) {
-                throw C2PAError.Api("roles cannot exceed $MAX_STRING_ARRAY_LEN entries")
-            }
-            if (referencedAssertions.any { it.isEmpty() }) {
-                throw C2PAError.Api("referencedAssertions cannot contain empty strings")
-            }
-            if (roles.any { it.isEmpty() }) {
-                throw C2PAError.Api("roles cannot contain empty strings")
+            if (roles.size >= MAX_STRING_ARRAY_LEN) {
+                throw C2PAError.Api("roles cannot exceed ${MAX_STRING_ARRAY_LEN - 1} entries")
             }
 
             return executeC2PAOperation("Failed to combine signers for CAWG identity") {

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -208,6 +208,11 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(signerTests.testStrongBoxAvailability())
     results.add(signerTests.testSignerFromSettingsToml())
     results.add(signerTests.testSignerFromSettingsJson())
+    results.add(signerTests.testCawgCombinedPemSigner())
+    results.add(signerTests.testCawgCombinedCallbackSigner())
+    results.add(signerTests.testCawgConsumesInputSigners())
+    results.add(signerTests.testCawgRejectsClosedSigner())
+    results.add(signerTests.testCawgCombinedStrongBoxIdentity())
 
     // Web Service Tests (if server is available)
     val webServiceTests = AppWebServiceTests(context)

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -212,6 +212,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(signerTests.testCawgCombinedCallbackSigner())
     results.add(signerTests.testCawgConsumesInputSigners())
     results.add(signerTests.testCawgRejectsClosedSigner())
+    results.add(signerTests.testCawgRejectsInvalidInputs())
     results.add(signerTests.testCawgCombinedStrongBoxIdentity())
 
     // Web Service Tests (if server is available)

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/SignerTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/SignerTests.kt
@@ -14,6 +14,13 @@ package org.contentauth.c2pa.test.shared
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.contentauth.c2pa.Builder
 import org.contentauth.c2pa.ByteArrayStream
 import org.contentauth.c2pa.C2PA
@@ -957,37 +964,68 @@ abstract class SignerTests : TestBase() {
         }
     }
 
-    protected fun assertCawgIdentityInManifest(
-        manifestJson: String,
-        expectedRefs: List<String>,
-    ): String {
-        if (!manifestJson.contains("cawg.identity")) {
+    /**
+     * Assert that the reader JSON contains a well-formed `cawg.identity` assertion: the
+     * assertion is present in the manifest, its `signer_payload.referenced_assertions`
+     * array is non-empty, and the active-manifest validation results include the
+     * `cawg.identity.well-formed` success code. The exact labels that c2pa-rs emits
+     * under `referenced_assertions` are implementation-defined and not asserted here.
+     */
+    protected fun assertCawgIdentityInManifest(manifestJson: String): String {
+        val root = Json.parseToJsonElement(manifestJson).jsonObject
+        val manifests = root["manifests"]?.jsonObject
+            ?: throw AssertionError("Reader JSON has no 'manifests' object. JSON: $manifestJson")
+
+        val cawgAssertions = manifests.values.flatMap { manifestEl ->
+            val assertions = manifestEl.jsonObject["assertions"]?.jsonArray ?: JsonArray(emptyList())
+            assertions.mapNotNull { it as? JsonObject }
+                .filter { it["label"]?.jsonPrimitive?.contentOrNull == "cawg.identity" }
+        }
+        if (cawgAssertions.isEmpty()) {
+            throw AssertionError("Expected a cawg.identity assertion. JSON: $manifestJson")
+        }
+        val foundRefs = cawgAssertions.flatMap { extractReferencedAssertionLabels(it) }
+        if (foundRefs.isEmpty()) {
             throw AssertionError(
-                "Expected manifest to contain a cawg.identity assertion. JSON: $manifestJson",
+                "cawg.identity assertion has no referenced_assertions entries. JSON: $manifestJson",
             )
         }
-        val missing = expectedRefs.filterNot { manifestJson.contains(it) }
-        if (missing.isNotEmpty()) {
+
+        val successCodes = root["validation_results"]?.jsonObject
+            ?.get("activeManifest")?.jsonObject
+            ?.get("success")?.jsonArray
+            ?.mapNotNull { (it as? JsonObject)?.get("code")?.jsonPrimitive?.contentOrNull }
+            ?: emptyList()
+        if ("cawg.identity.well-formed" !in successCodes) {
             throw AssertionError(
-                "cawg.identity assertion missing referenced labels: $missing. JSON: $manifestJson",
+                "validation_results missing cawg.identity.well-formed success code. JSON: $manifestJson",
             )
         }
-        return "cawg.identity present; refs=${expectedRefs.joinToString(",")}"
+
+        return "cawg.identity well-formed; refs=${foundRefs.joinToString(",")}"
     }
 
-    private fun pemSignCallback(privateKeyPem: String): (ByteArray) -> ByteArray = { data ->
-        val keyBytes = Base64.getDecoder().decode(
-            privateKeyPem
-                .replace("-----BEGIN PRIVATE KEY-----", "")
-                .replace("-----END PRIVATE KEY-----", "")
-                .replace("\\s".toRegex(), ""),
-        )
-        val privateKey = KeyFactory.getInstance("EC")
-            .generatePrivate(PKCS8EncodedKeySpec(keyBytes))
-        val sig = Signature.getInstance("SHA256withECDSA")
-        sig.initSign(privateKey)
-        sig.update(data)
-        derToRawSignature(sig.sign(), 32)
+    /**
+     * Extract the assertion labels referenced by a `cawg.identity` assertion. The c2pa-rs
+     * reader emits these under `data.signer_payload.referenced_assertions[*].url` as JUMBF
+     * URIs like `self#jumbf=c2pa.assertions/c2pa.actions`; the label is the last path segment.
+     */
+    private fun extractReferencedAssertionLabels(cawgAssertion: JsonObject): List<String> {
+        val payload = cawgAssertion["data"]?.jsonObject?.get("signer_payload")?.jsonObject
+            ?: return emptyList()
+        val refs = payload["referenced_assertions"]?.jsonArray ?: return emptyList()
+        return refs.mapNotNull { ref ->
+            val obj = ref as? JsonObject ?: return@mapNotNull null
+            val url = obj["url"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            url.substringAfterLast('/')
+        }
+    }
+
+    private fun pemSignCallback(
+        privateKeyPem: String,
+        algorithm: SigningAlgorithm = SigningAlgorithm.ES256,
+    ): (ByteArray) -> ByteArray = { data ->
+        SigningHelper.signWithPEMKey(data, privateKeyPem, algorithm.description.uppercase())
     }
 
     suspend fun testCawgCombinedPemSigner(): TestResult = withContext(Dispatchers.IO) {
@@ -1019,7 +1057,7 @@ abstract class SignerTests : TestBase() {
                 }
 
                 val readerJson = C2PA.readFile(destFile.absolutePath)
-                val detail = assertCawgIdentityInManifest(readerJson, listOf("c2pa.actions"))
+                val detail = assertCawgIdentityInManifest(readerJson)
                 TestResult(
                     "CAWG Combined Signer (PEM + PEM)",
                     true,
@@ -1071,7 +1109,7 @@ abstract class SignerTests : TestBase() {
                 }
 
                 val readerJson = C2PA.readFile(destFile.absolutePath)
-                val detail = assertCawgIdentityInManifest(readerJson, listOf("c2pa.actions"))
+                val detail = assertCawgIdentityInManifest(readerJson)
                 TestResult(
                     "CAWG Combined Signer (Callback + Callback)",
                     true,
@@ -1108,13 +1146,13 @@ abstract class SignerTests : TestBase() {
                     "Inputs safely closeable after combine",
                     "no crash",
                 )
-            } catch (t: Throwable) {
+            } catch (e: Exception) {
                 combined.close()
                 TestResult(
                     "CAWG Combined Signer Consumes Inputs",
                     false,
-                    "Closing consumed inputs crashed: ${t.message}",
-                    t::class.simpleName ?: "",
+                    "Closing consumed inputs crashed: ${e.message}",
+                    e::class.simpleName ?: "",
                 )
             }
         }
@@ -1186,7 +1224,7 @@ abstract class SignerTests : TestBase() {
                 }
 
                 val readerJson = C2PA.readFile(destFile.absolutePath)
-                val detail = assertCawgIdentityInManifest(readerJson, listOf("c2pa.actions"))
+                val detail = assertCawgIdentityInManifest(readerJson)
                 TestResult(
                     "CAWG Combined Signer (StrongBox Identity)",
                     true,

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/SignerTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/SignerTests.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.withContext
 import org.contentauth.c2pa.Builder
 import org.contentauth.c2pa.ByteArrayStream
 import org.contentauth.c2pa.C2PA
+import org.contentauth.c2pa.C2PAError
 import org.contentauth.c2pa.CertificateManager
 import org.contentauth.c2pa.FileStream
 import org.contentauth.c2pa.KeyStoreSigner
@@ -951,6 +952,283 @@ abstract class SignerTests : TestBase() {
                     false,
                     "Test failed with exception",
                     "${e.javaClass.simpleName}: ${e.message}",
+                )
+            }
+        }
+    }
+
+    protected fun assertCawgIdentityInManifest(
+        manifestJson: String,
+        expectedRefs: List<String>,
+    ): String {
+        if (!manifestJson.contains("cawg.identity")) {
+            throw AssertionError(
+                "Expected manifest to contain a cawg.identity assertion. JSON: $manifestJson",
+            )
+        }
+        val missing = expectedRefs.filterNot { manifestJson.contains(it) }
+        if (missing.isNotEmpty()) {
+            throw AssertionError(
+                "cawg.identity assertion missing referenced labels: $missing. JSON: $manifestJson",
+            )
+        }
+        return "cawg.identity present; refs=${expectedRefs.joinToString(",")}"
+    }
+
+    private fun pemSignCallback(privateKeyPem: String): (ByteArray) -> ByteArray = { data ->
+        val keyBytes = Base64.getDecoder().decode(
+            privateKeyPem
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replace("\\s".toRegex(), ""),
+        )
+        val privateKey = KeyFactory.getInstance("EC")
+            .generatePrivate(PKCS8EncodedKeySpec(keyBytes))
+        val sig = Signature.getInstance("SHA256withECDSA")
+        sig.initSign(privateKey)
+        sig.update(data)
+        derToRawSignature(sig.sign(), 32)
+    }
+
+    suspend fun testCawgCombinedPemSigner(): TestResult = withContext(Dispatchers.IO) {
+        runTest("CAWG Combined Signer (PEM + PEM)") {
+            val manifestJson = TEST_MANIFEST_JSON
+            val certPem = loadResourceAsString("es256_certs")
+            val keyPem = loadResourceAsString("es256_private")
+            val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+
+            val c2paSigner = Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256)
+            val identitySigner = Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256)
+
+            val combined = Signer.withCawgIdentity(
+                c2pa = c2paSigner,
+                identity = identitySigner,
+                referencedAssertions = listOf("c2pa.actions"),
+            )
+
+            val destFile = File.createTempFile("cawg_combined_pem", ".jpg")
+            try {
+                combined.use { signer ->
+                    Builder.fromJson(manifestJson).use { builder ->
+                        ByteArrayStream(sourceImageData).use { src ->
+                            FileStream(destFile).use { dst ->
+                                builder.sign("image/jpeg", src, dst, signer)
+                            }
+                        }
+                    }
+                }
+
+                val readerJson = C2PA.readFile(destFile.absolutePath)
+                val detail = assertCawgIdentityInManifest(readerJson, listOf("c2pa.actions"))
+                TestResult(
+                    "CAWG Combined Signer (PEM + PEM)",
+                    true,
+                    "Combined PEM signing succeeded",
+                    detail,
+                )
+            } finally {
+                destFile.delete()
+            }
+        }
+    }
+
+    suspend fun testCawgCombinedCallbackSigner(): TestResult = withContext(Dispatchers.IO) {
+        runTest("CAWG Combined Signer (Callback + Callback)") {
+            val manifestJson = TEST_MANIFEST_JSON
+            val certPem = loadResourceAsString("es256_certs")
+            val keyPem = loadResourceAsString("es256_private")
+            val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+
+            val pemSign = pemSignCallback(keyPem)
+
+            val c2paSigner = Signer.withCallback(
+                SigningAlgorithm.ES256,
+                certPem,
+                sign = pemSign,
+            )
+            val identitySigner = Signer.withCallback(
+                SigningAlgorithm.ES256,
+                certPem,
+                sign = pemSign,
+            )
+
+            val combined = Signer.withCawgIdentity(
+                c2pa = c2paSigner,
+                identity = identitySigner,
+                referencedAssertions = listOf("c2pa.actions"),
+            )
+
+            val destFile = File.createTempFile("cawg_combined_callback", ".jpg")
+            try {
+                combined.use { signer ->
+                    Builder.fromJson(manifestJson).use { builder ->
+                        ByteArrayStream(sourceImageData).use { src ->
+                            FileStream(destFile).use { dst ->
+                                builder.sign("image/jpeg", src, dst, signer)
+                            }
+                        }
+                    }
+                }
+
+                val readerJson = C2PA.readFile(destFile.absolutePath)
+                val detail = assertCawgIdentityInManifest(readerJson, listOf("c2pa.actions"))
+                TestResult(
+                    "CAWG Combined Signer (Callback + Callback)",
+                    true,
+                    "Combined callback signing succeeded",
+                    detail,
+                )
+            } finally {
+                destFile.delete()
+            }
+        }
+    }
+
+    suspend fun testCawgConsumesInputSigners(): TestResult = withContext(Dispatchers.IO) {
+        runTest("CAWG Combined Signer Consumes Inputs") {
+            val certPem = loadResourceAsString("es256_certs")
+            val keyPem = loadResourceAsString("es256_private")
+
+            val c2paSigner = Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256)
+            val identitySigner = Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256)
+
+            val combined = Signer.withCawgIdentity(
+                c2pa = c2paSigner,
+                identity = identitySigner,
+                referencedAssertions = listOf("c2pa.actions"),
+            )
+            try {
+                c2paSigner.close()
+                identitySigner.close()
+                combined.close()
+                combined.close()
+                TestResult(
+                    "CAWG Combined Signer Consumes Inputs",
+                    true,
+                    "Inputs safely closeable after combine",
+                    "no crash",
+                )
+            } catch (t: Throwable) {
+                combined.close()
+                TestResult(
+                    "CAWG Combined Signer Consumes Inputs",
+                    false,
+                    "Closing consumed inputs crashed: ${t.message}",
+                    t::class.simpleName ?: "",
+                )
+            }
+        }
+    }
+
+    suspend fun testCawgCombinedStrongBoxIdentity(): TestResult = withContext(Dispatchers.IO) {
+        val signingServerAvailable = isSigningServerAvailable()
+        if (!signingServerAvailable) {
+            return@withContext TestResult(
+                "CAWG Combined Signer (StrongBox Identity)",
+                true,
+                "SKIPPED: Signing server not available",
+                status = TestStatus.SKIPPED,
+            )
+        }
+
+        runTest("CAWG Combined Signer (StrongBox Identity)") {
+            val hasStrongBox = StrongBoxSigner.isAvailable(getContext())
+            if (!hasStrongBox) {
+                return@runTest TestResult(
+                    "CAWG Combined Signer (StrongBox Identity)",
+                    true,
+                    "StrongBox not available on this device (expected)",
+                    "Device does not support StrongBox",
+                )
+            }
+
+            val manifestJson = TEST_MANIFEST_JSON
+            val certPem = loadResourceAsString("es256_certs")
+            val keyPem = loadResourceAsString("es256_private")
+            val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+
+            val c2paSigner = Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256)
+
+            val identityKeyTag = "cawg_identity_strongbox_${System.currentTimeMillis()}"
+            val identitySigner = CertificateManager.createStrongBoxSignerWithCSR(
+                algorithm = SigningAlgorithm.ES256,
+                strongBoxConfig = StrongBoxSigner.Config(
+                    keyTag = identityKeyTag,
+                    requireUserAuthentication = false,
+                ),
+                certificateConfig = CertificateManager.CertificateConfig(
+                    commonName = "CAWG StrongBox Identity",
+                    organization = "C2PA Test Suite",
+                    organizationalUnit = "Testing",
+                    country = "US",
+                    state = "CA",
+                    locality = "San Francisco",
+                ),
+                signingServerUrl = getServerUrl(),
+            )
+
+            val combined = Signer.withCawgIdentity(
+                c2pa = c2paSigner,
+                identity = identitySigner,
+                referencedAssertions = listOf("c2pa.actions"),
+            )
+
+            val destFile = File.createTempFile("cawg_combined_strongbox", ".jpg")
+            try {
+                combined.use { signer ->
+                    Builder.fromJson(manifestJson).use { builder ->
+                        ByteArrayStream(sourceImageData).use { src ->
+                            FileStream(destFile).use { dst ->
+                                builder.sign("image/jpeg", src, dst, signer)
+                            }
+                        }
+                    }
+                }
+
+                val readerJson = C2PA.readFile(destFile.absolutePath)
+                val detail = assertCawgIdentityInManifest(readerJson, listOf("c2pa.actions"))
+                TestResult(
+                    "CAWG Combined Signer (StrongBox Identity)",
+                    true,
+                    "Combined signing with StrongBox identity succeeded",
+                    detail,
+                )
+            } finally {
+                destFile.delete()
+                StrongBoxSigner.deleteKey(identityKeyTag)
+            }
+        }
+    }
+
+    suspend fun testCawgRejectsClosedSigner(): TestResult = withContext(Dispatchers.IO) {
+        runTest("CAWG Combined Signer Rejects Closed Input") {
+            val certPem = loadResourceAsString("es256_certs")
+            val keyPem = loadResourceAsString("es256_private")
+
+            val c2paSigner = Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256)
+            val identitySigner = Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256)
+            identitySigner.close()
+
+            try {
+                Signer.withCawgIdentity(
+                    c2pa = c2paSigner,
+                    identity = identitySigner,
+                    referencedAssertions = listOf("c2pa.actions"),
+                )
+                c2paSigner.close()
+                TestResult(
+                    "CAWG Combined Signer Rejects Closed Input",
+                    false,
+                    "Expected C2PAError but call succeeded",
+                    "no exception",
+                )
+            } catch (e: C2PAError) {
+                c2paSigner.close()
+                TestResult(
+                    "CAWG Combined Signer Rejects Closed Input",
+                    true,
+                    "Threw C2PAError as expected",
+                    e.message ?: "",
                 )
             }
         }

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/SignerTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/SignerTests.kt
@@ -1025,15 +1025,37 @@ abstract class SignerTests : TestBase() {
         privateKeyPem: String,
         algorithm: SigningAlgorithm = SigningAlgorithm.ES256,
     ): (ByteArray) -> ByteArray = { data ->
-        SigningHelper.signWithPEMKey(data, privateKeyPem, algorithm.description.uppercase())
+        SigningHelper.signWithPEMKey(data, privateKeyPem, algorithm.name)
+    }
+
+    /**
+     * Sign the test image into a temp file with [signer] (closing it), read the result
+     * back, and assert it carries a well-formed `cawg.identity` assertion. Returns the
+     * detail string produced by [assertCawgIdentityInManifest].
+     */
+    private fun signAndVerifyCawgManifest(signer: Signer, tempPrefix: String): String {
+        val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+        val destFile = File.createTempFile(tempPrefix, ".jpg")
+        return try {
+            signer.use { s ->
+                Builder.fromJson(TEST_MANIFEST_JSON).use { builder ->
+                    ByteArrayStream(sourceImageData).use { src ->
+                        FileStream(destFile).use { dst ->
+                            builder.sign("image/jpeg", src, dst, s)
+                        }
+                    }
+                }
+            }
+            assertCawgIdentityInManifest(C2PA.readFile(destFile.absolutePath))
+        } finally {
+            destFile.delete()
+        }
     }
 
     suspend fun testCawgCombinedPemSigner(): TestResult = withContext(Dispatchers.IO) {
         runTest("CAWG Combined Signer (PEM + PEM)") {
-            val manifestJson = TEST_MANIFEST_JSON
             val certPem = loadResourceAsString("es256_certs")
             val keyPem = loadResourceAsString("es256_private")
-            val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
 
             val c2paSigner = Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256)
             val identitySigner = Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256)
@@ -1044,38 +1066,20 @@ abstract class SignerTests : TestBase() {
                 referencedAssertions = listOf("c2pa.actions"),
             )
 
-            val destFile = File.createTempFile("cawg_combined_pem", ".jpg")
-            try {
-                combined.use { signer ->
-                    Builder.fromJson(manifestJson).use { builder ->
-                        ByteArrayStream(sourceImageData).use { src ->
-                            FileStream(destFile).use { dst ->
-                                builder.sign("image/jpeg", src, dst, signer)
-                            }
-                        }
-                    }
-                }
-
-                val readerJson = C2PA.readFile(destFile.absolutePath)
-                val detail = assertCawgIdentityInManifest(readerJson)
-                TestResult(
-                    "CAWG Combined Signer (PEM + PEM)",
-                    true,
-                    "Combined PEM signing succeeded",
-                    detail,
-                )
-            } finally {
-                destFile.delete()
-            }
+            val detail = signAndVerifyCawgManifest(combined, "cawg_combined_pem")
+            TestResult(
+                "CAWG Combined Signer (PEM + PEM)",
+                true,
+                "Combined PEM signing succeeded",
+                detail,
+            )
         }
     }
 
     suspend fun testCawgCombinedCallbackSigner(): TestResult = withContext(Dispatchers.IO) {
         runTest("CAWG Combined Signer (Callback + Callback)") {
-            val manifestJson = TEST_MANIFEST_JSON
             val certPem = loadResourceAsString("es256_certs")
             val keyPem = loadResourceAsString("es256_private")
-            val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
 
             val pemSign = pemSignCallback(keyPem)
 
@@ -1096,29 +1100,13 @@ abstract class SignerTests : TestBase() {
                 referencedAssertions = listOf("c2pa.actions"),
             )
 
-            val destFile = File.createTempFile("cawg_combined_callback", ".jpg")
-            try {
-                combined.use { signer ->
-                    Builder.fromJson(manifestJson).use { builder ->
-                        ByteArrayStream(sourceImageData).use { src ->
-                            FileStream(destFile).use { dst ->
-                                builder.sign("image/jpeg", src, dst, signer)
-                            }
-                        }
-                    }
-                }
-
-                val readerJson = C2PA.readFile(destFile.absolutePath)
-                val detail = assertCawgIdentityInManifest(readerJson)
-                TestResult(
-                    "CAWG Combined Signer (Callback + Callback)",
-                    true,
-                    "Combined callback signing succeeded",
-                    detail,
-                )
-            } finally {
-                destFile.delete()
-            }
+            val detail = signAndVerifyCawgManifest(combined, "cawg_combined_callback")
+            TestResult(
+                "CAWG Combined Signer (Callback + Callback)",
+                true,
+                "Combined callback signing succeeded",
+                detail,
+            )
         }
     }
 
@@ -1180,10 +1168,8 @@ abstract class SignerTests : TestBase() {
                 )
             }
 
-            val manifestJson = TEST_MANIFEST_JSON
             val certPem = loadResourceAsString("es256_certs")
             val keyPem = loadResourceAsString("es256_private")
-            val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
 
             val c2paSigner = Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256)
 
@@ -1211,20 +1197,8 @@ abstract class SignerTests : TestBase() {
                 referencedAssertions = listOf("c2pa.actions"),
             )
 
-            val destFile = File.createTempFile("cawg_combined_strongbox", ".jpg")
             try {
-                combined.use { signer ->
-                    Builder.fromJson(manifestJson).use { builder ->
-                        ByteArrayStream(sourceImageData).use { src ->
-                            FileStream(destFile).use { dst ->
-                                builder.sign("image/jpeg", src, dst, signer)
-                            }
-                        }
-                    }
-                }
-
-                val readerJson = C2PA.readFile(destFile.absolutePath)
-                val detail = assertCawgIdentityInManifest(readerJson)
+                val detail = signAndVerifyCawgManifest(combined, "cawg_combined_strongbox")
                 TestResult(
                     "CAWG Combined Signer (StrongBox Identity)",
                     true,
@@ -1232,7 +1206,6 @@ abstract class SignerTests : TestBase() {
                     detail,
                 )
             } finally {
-                destFile.delete()
                 StrongBoxSigner.deleteKey(identityKeyTag)
             }
         }
@@ -1252,8 +1225,7 @@ abstract class SignerTests : TestBase() {
                     c2pa = c2paSigner,
                     identity = identitySigner,
                     referencedAssertions = listOf("c2pa.actions"),
-                )
-                c2paSigner.close()
+                ).close()
                 TestResult(
                     "CAWG Combined Signer Rejects Closed Input",
                     false,
@@ -1261,13 +1233,77 @@ abstract class SignerTests : TestBase() {
                     "no exception",
                 )
             } catch (e: C2PAError) {
-                c2paSigner.close()
                 TestResult(
                     "CAWG Combined Signer Rejects Closed Input",
                     true,
                     "Threw C2PAError as expected",
                     e.message ?: "",
                 )
+            } finally {
+                c2paSigner.close()
+            }
+        }
+    }
+
+    suspend fun testCawgRejectsInvalidInputs(): TestResult = withContext(Dispatchers.IO) {
+        runTest("CAWG Combined Signer Rejects Invalid Inputs") {
+            val testName = "CAWG Combined Signer Rejects Invalid Inputs"
+            val certPem = loadResourceAsString("es256_certs")
+            val keyPem = loadResourceAsString("es256_private")
+
+            Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256).use { c2paSigner ->
+                Signer.fromKeys(certPem, keyPem, SigningAlgorithm.ES256).use { identitySigner ->
+                    val failures = mutableListOf<String>()
+
+                    try {
+                        Signer.withCawgIdentity(
+                            c2pa = c2paSigner,
+                            identity = c2paSigner,
+                            referencedAssertions = listOf("c2pa.actions"),
+                        ).close()
+                        failures.add("same-instance signers were accepted")
+                    } catch (e: C2PAError) {
+                        // Expected: aliasing the same signer would consume it twice.
+                    }
+
+                    try {
+                        Signer.withCawgIdentity(
+                            c2pa = c2paSigner,
+                            identity = identitySigner,
+                            referencedAssertions = List(256) { "c2pa.actions" },
+                        ).close()
+                        failures.add("256-entry referencedAssertions list was accepted")
+                    } catch (e: C2PAError) {
+                        // Expected: the FFI's per-array limit allows at most 255 entries.
+                    }
+
+                    // Rejected calls must not have consumed the inputs. Only probe when
+                    // both rejections threw; otherwise the inputs may be consumed and
+                    // the probe would pass a freed signer to the FFI.
+                    if (failures.isEmpty()) {
+                        try {
+                            if (c2paSigner.reserveSize() <= 0) {
+                                failures.add("c2pa signer unusable after rejected calls")
+                            }
+                            if (identitySigner.reserveSize() <= 0) {
+                                failures.add("identity signer unusable after rejected calls")
+                            }
+                        } catch (e: C2PAError) {
+                            failures.add("input signer consumed by a rejected call: ${e.message}")
+                        }
+                    }
+
+                    if (failures.isEmpty()) {
+                        TestResult(
+                            testName,
+                            true,
+                            "Invalid inputs rejected without consuming signers",
+                            "same-instance and oversized list both rejected",
+                        )
+                    } else {
+                        TestResult(testName, false, failures.joinToString("; "), "")
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Changes in this pull request
Adds support for creating a Signer that combines a standard + an identity signer to allow CAWG x509 signing.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment