### PR TITLE
fix: Callback safety

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -172,6 +172,12 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestContextCloseDuringSign() = runBlocking {
+        val result = testContextCloseDuringSign()
+        assertTrue(result.success, "Context Close During Sign test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestContextHttpResolverRemoteFetch() = runBlocking {
         val result = testContextHttpResolverRemoteFetch()
         assertTrue(result.success, "Context HTTP Resolver Remote Fetch test failed: ${result.message}")

--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidStreamTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidStreamTests.kt
@@ -46,6 +46,12 @@ class AndroidStreamTests : StreamTests() {
     }
 
     @Test
+    fun runTestStreamExceptionPropagation() = runBlocking {
+        val result = testStreamExceptionPropagation()
+        assertTrue(result.success, "Stream Exception Propagation test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestStreamFileOptions() = runBlocking {
         val result = testStreamFileOptions()
         assertTrue(result.success, "Stream File Options test failed: ${result.message}")

--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidStreamTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidStreamTests.kt
@@ -52,6 +52,12 @@ class AndroidStreamTests : StreamTests() {
     }
 
     @Test
+    fun runTestStreamWriteExceptionPropagation() = runBlocking {
+        val result = testStreamWriteExceptionPropagation()
+        assertTrue(result.success, "Stream Write Exception Propagation test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestStreamFileOptions() = runBlocking {
         val result = testStreamFileOptions()
         assertTrue(result.success, "Stream File Options test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -36,20 +36,28 @@ typedef struct {
     jobject streamObject;  // Global reference
 } JavaStreamContext;
 
-// Signer callback context
+// Signer callback context. The core may invoke a callback with its user_data
+// pointer at any time until every object derived from the owning signer is
+// gone, and provides no destructor hook, so a trampoline must never
+// dereference the raw pointer it is handed. Instead, liveness is a registry
+// lookup: a context is invocable only while it is present in its registry, and
+// refCount (guarded by the registry mutex, one reference held by the registry
+// and one per in-flight invocation) defers the free until the last holder
+// releases. A stale pointer from the core is simply not found and ignored.
 typedef struct {
     jobject callback;      // Global reference
     jmethodID signMethod;
-    jboolean isActive;     // Track if context is still valid
+    int refCount;
 } JavaSignerContext;
 
 // Context-builder callback context (progress observer / HTTP resolver).
-// Lifetime: created on the builder, ownership transferred to the built C2PAContext,
-// and freed when that context is closed. Mirrors the signer-callback pattern.
+// Created on the builder, ownership transferred to the built C2PAContext, and
+// released when that context is closed, with the same registry-lookup liveness
+// scheme as JavaSignerContext (under g_contextCallbacksMutex).
 typedef struct {
     jobject callback;      // Global reference to the Kotlin bridge object
     jmethodID method;      // Cached bridge method id
-    jboolean isActive;
+    int refCount;
 } JavaContextCallback;
 
 typedef struct SignerContextNode {
@@ -58,8 +66,15 @@ typedef struct SignerContextNode {
     struct SignerContextNode *next;
 } SignerContextNode;
 
+typedef struct ContextCallbackNode {
+    JavaContextCallback *context;
+    struct ContextCallbackNode *next;
+} ContextCallbackNode;
+
 static SignerContextNode *g_signerContexts = NULL;
 static pthread_mutex_t g_signerContextsMutex = PTHREAD_MUTEX_INITIALIZER;
+static ContextCallbackNode *g_contextCallbacks = NULL;
+static pthread_mutex_t g_contextCallbacksMutex = PTHREAD_MUTEX_INITIALIZER;
 
 // JNI OnLoad - save JavaVM reference and cache IDs
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
@@ -98,26 +113,29 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
 // Cleanup all remaining signer contexts
 static void cleanup_all_signer_contexts(JNIEnv *env) {
     pthread_mutex_lock(&g_signerContextsMutex);
-    
-    SignerContextNode *current = g_signerContexts;
-    while (current != NULL) {
-        SignerContextNode *next = current->next;
-        JavaSignerContext *ctx = current->context;
-        
-        if (ctx != NULL) {
-            ctx->isActive = JNI_FALSE;
-            if (ctx->callback != NULL) {
-                (*env)->DeleteGlobalRef(env, ctx->callback);
-            }
-            free(ctx);
-        }
-        
-        free(current);
-        current = next;
-    }
-    
+    SignerContextNode *detached = g_signerContexts;
     g_signerContexts = NULL;
     pthread_mutex_unlock(&g_signerContextsMutex);
+
+    while (detached != NULL) {
+        SignerContextNode *next = detached->next;
+        JavaSignerContext *ctx = detached->context;
+
+        if (ctx != NULL) {
+            pthread_mutex_lock(&g_signerContextsMutex);
+            int remaining = --ctx->refCount;
+            pthread_mutex_unlock(&g_signerContextsMutex);
+            if (remaining == 0) {
+                if (ctx->callback != NULL) {
+                    (*env)->DeleteGlobalRef(env, ctx->callback);
+                }
+                free(ctx);
+            }
+        }
+
+        free(detached);
+        detached = next;
+    }
 }
 
 // JNI OnUnload - cleanup global references
@@ -382,21 +400,106 @@ static intptr_t java_flush_callback(struct StreamContext *context) {
     return (intptr_t)result;
 }
 
-// Signer callback function
-static intptr_t java_signer_callback(const void *context, const unsigned char *data, uintptr_t len, 
-                                    unsigned char *signed_bytes, uintptr_t signed_len) {
-    JavaSignerContext *jctx = (JavaSignerContext*)context;
-    
-    // Check if context is still valid
-    if (!jctx->isActive) {
-        return -1;
+// Acquire a signer context for a callback invocation. The pointer handed to us
+// by the core is only dereferenced after it has been found in the registry, so
+// a stale pointer for an already-released context is ignored rather than read.
+// Returns JNI_FALSE when not found. Must be paired with release_signer_context.
+static jboolean acquire_signer_context(JavaSignerContext *ctx) {
+    jboolean found = JNI_FALSE;
+    pthread_mutex_lock(&g_signerContextsMutex);
+    for (SignerContextNode *node = g_signerContexts; node != NULL; node = node->next) {
+        if (node->context == ctx) {
+            ctx->refCount++;
+            found = JNI_TRUE;
+            break;
+        }
     }
-    
-    JNIEnv *env = get_jni_env();
-    if (env == NULL) {
-        return -1;
+    pthread_mutex_unlock(&g_signerContextsMutex);
+    return found;
+}
+
+// Drop one reference to a signer context, freeing it (and its callback global
+// ref) once the last reference is gone. If env is NULL the global ref cannot be
+// deleted and is leaked; the struct is still freed.
+static void release_signer_context(JNIEnv *env, JavaSignerContext *ctx) {
+    pthread_mutex_lock(&g_signerContextsMutex);
+    int remaining = --ctx->refCount;
+    pthread_mutex_unlock(&g_signerContextsMutex);
+    if (remaining == 0) {
+        if (env != NULL && ctx->callback != NULL) {
+            (*env)->DeleteGlobalRef(env, ctx->callback);
+        }
+        free(ctx);
     }
-    
+}
+
+// Registry lookup acquire/release for context-builder callbacks, same scheme as
+// the signer context.
+static jboolean acquire_context_callback(JavaContextCallback *ctx) {
+    jboolean found = JNI_FALSE;
+    pthread_mutex_lock(&g_contextCallbacksMutex);
+    for (ContextCallbackNode *node = g_contextCallbacks; node != NULL; node = node->next) {
+        if (node->context == ctx) {
+            ctx->refCount++;
+            found = JNI_TRUE;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&g_contextCallbacksMutex);
+    return found;
+}
+
+static void release_context_callback(JNIEnv *env, JavaContextCallback *ctx) {
+    pthread_mutex_lock(&g_contextCallbacksMutex);
+    int remaining = --ctx->refCount;
+    pthread_mutex_unlock(&g_contextCallbacksMutex);
+    if (remaining == 0) {
+        if (env != NULL && ctx->callback != NULL) {
+            (*env)->DeleteGlobalRef(env, ctx->callback);
+        }
+        free(ctx);
+    }
+}
+
+// Adds a context callback to the live registry, making it invocable. Returns
+// JNI_FALSE on allocation failure.
+static jboolean register_context_callback(JavaContextCallback *ctx) {
+    ContextCallbackNode *node = (ContextCallbackNode*)malloc(sizeof(ContextCallbackNode));
+    if (node == NULL) {
+        return JNI_FALSE;
+    }
+    node->context = ctx;
+    pthread_mutex_lock(&g_contextCallbacksMutex);
+    node->next = g_contextCallbacks;
+    g_contextCallbacks = node;
+    pthread_mutex_unlock(&g_contextCallbacksMutex);
+    return JNI_TRUE;
+}
+
+// Removes a context callback from the live registry. Later invocations from the
+// core no longer find it and are ignored. Returns JNI_TRUE if it was present.
+static jboolean unregister_context_callback(JavaContextCallback *ctx) {
+    jboolean removed = JNI_FALSE;
+    pthread_mutex_lock(&g_contextCallbacksMutex);
+    ContextCallbackNode **current = &g_contextCallbacks;
+    while (*current != NULL) {
+        if ((*current)->context == ctx) {
+            ContextCallbackNode *node = *current;
+            *current = node->next;
+            free(node);
+            removed = JNI_TRUE;
+            break;
+        }
+        current = &(*current)->next;
+    }
+    pthread_mutex_unlock(&g_contextCallbacksMutex);
+    return removed;
+}
+
+// Body of the signer callback, run while holding a reference on jctx.
+static intptr_t java_signer_callback_invoke(JNIEnv *env, JavaSignerContext *jctx,
+                                            const unsigned char *data, uintptr_t len,
+                                            unsigned char *signed_bytes, uintptr_t signed_len) {
     // Create byte array from data
     if (len > INT32_MAX) {
         throw_c2pa_exception(env, "Requested buffer too large for JNI");
@@ -443,42 +546,47 @@ static intptr_t java_signer_callback(const void *context, const unsigned char *d
     return sig_len;
 }
 
+// Signer callback function
+static intptr_t java_signer_callback(const void *context, const unsigned char *data, uintptr_t len,
+                                    unsigned char *signed_bytes, uintptr_t signed_len) {
+    JavaSignerContext *jctx = (JavaSignerContext*)context;
+    if (jctx == NULL || !acquire_signer_context(jctx)) {
+        return -1;
+    }
+
+    JNIEnv *env = get_jni_env();
+    intptr_t result = -1;
+    if (env != NULL) {
+        result = java_signer_callback_invoke(env, jctx, data, len, signed_bytes, signed_len);
+    }
+
+    release_signer_context(env, jctx);
+    return result;
+}
+
 // Progress callback trampoline. The Kotlin side is a Void observer, so this always
 // returns 1 (continue) — cancellation is exposed separately via C2PAContext.cancel().
 static int java_progress_callback(const void *context, enum C2paProgressPhase phase, uint32_t step, uint32_t total) {
     JavaContextCallback *jctx = (JavaContextCallback*)context;
-    if (jctx == NULL || !jctx->isActive) {
+    if (jctx == NULL || !acquire_context_callback(jctx)) {
         return 1;
     }
 
     JNIEnv *env = get_jni_env();
-    if (env == NULL) {
-        return 1;
+    if (env != NULL) {
+        // Bridge signature: onProgress(int phase, long step, long total) -> void
+        (*env)->CallVoidMethod(env, jctx->callback, jctx->method, (jint)phase, (jlong)step, (jlong)total);
+        check_exception(env);
     }
 
-    // Bridge signature: onProgress(int phase, long step, long total) -> void
-    (*env)->CallVoidMethod(env, jctx->callback, jctx->method, (jint)phase, (jlong)step, (jlong)total);
-    check_exception(env);
+    release_context_callback(env, jctx);
     return 1;
 }
 
-// HTTP resolver trampoline. Marshals the C request into the Kotlin bridge, reads back
-// status + body from the returned HttpResponse, and mallocs the body for Rust to free.
-// Returns 0 on success, -1 on error (with c2pa_error_set_last set).
-static int java_http_resolver_callback(void *context, const struct C2paHttpRequest *request,
-                                       struct C2paHttpResponse *response) {
-    JavaContextCallback *jctx = (JavaContextCallback*)context;
-    if (jctx == NULL || !jctx->isActive) {
-        c2pa_error_set_last("HTTP resolver is no longer active");
-        return -1;
-    }
-
-    JNIEnv *env = get_jni_env();
-    if (env == NULL) {
-        c2pa_error_set_last("Failed to attach JNI environment for HTTP resolver");
-        return -1;
-    }
-
+// Body of the HTTP resolver callback, run while holding a reference on jctx.
+static int java_http_resolver_invoke(JNIEnv *env, JavaContextCallback *jctx,
+                                     const struct C2paHttpRequest *request,
+                                     struct C2paHttpResponse *response) {
     jstring jurl = (request->url != NULL) ? cstring_to_jstring(env, request->url) : NULL;
     jstring jmethod = (request->method != NULL) ? cstring_to_jstring(env, request->method) : NULL;
     jstring jheaders = (request->headers != NULL) ? cstring_to_jstring(env, request->headers) : NULL;
@@ -538,6 +646,29 @@ static int java_http_resolver_callback(void *context, const struct C2paHttpReque
     }
 
     return 0;
+}
+
+// HTTP resolver trampoline. Marshals the C request into the Kotlin bridge, reads back
+// status + body from the returned HttpResponse, and mallocs the body for Rust to free.
+// Returns 0 on success, -1 on error (with c2pa_error_set_last set).
+static int java_http_resolver_callback(void *context, const struct C2paHttpRequest *request,
+                                       struct C2paHttpResponse *response) {
+    JavaContextCallback *jctx = (JavaContextCallback*)context;
+    if (jctx == NULL || !acquire_context_callback(jctx)) {
+        c2pa_error_set_last("HTTP resolver is no longer active");
+        return -1;
+    }
+
+    JNIEnv *env = get_jni_env();
+    int result = -1;
+    if (env == NULL) {
+        c2pa_error_set_last("Failed to attach JNI environment for HTTP resolver");
+    } else {
+        result = java_http_resolver_invoke(env, jctx, request, response);
+    }
+
+    release_context_callback(env, jctx);
+    return result;
 }
 
 // Native methods implementation
@@ -1513,37 +1644,50 @@ static void register_signer_context(struct C2paSigner *signer, JavaSignerContext
     }
 }
 
-// Unregister and free all signer contexts associated with a signer
-// (a CAWG combined signer may carry more than one after attach_signer_contexts).
+// Unregister all signer contexts associated with a signer (a CAWG combined
+// signer may carry more than one after attach_signer_contexts). Each context is
+// marked inactive and the registry's reference dropped; a context with an
+// in-flight callback stays allocated until that callback releases it.
 static void unregister_signer_context(struct C2paSigner *signer) {
-    pthread_mutex_lock(&g_signerContextsMutex);
+    SignerContextNode *toFree = NULL;
 
+    pthread_mutex_lock(&g_signerContextsMutex);
     SignerContextNode **current = &g_signerContexts;
     while (*current != NULL) {
         if ((*current)->signer == signer) {
-            SignerContextNode *toDelete = *current;
-            JavaSignerContext *ctx = toDelete->context;
+            SignerContextNode *node = *current;
+            *current = node->next;
+            JavaSignerContext *ctx = node->context;
 
-            // Mark context as inactive
             if (ctx != NULL) {
-                ctx->isActive = JNI_FALSE;
-
-                JNIEnv *env = get_jni_env();
-                if (env != NULL && ctx->callback != NULL) {
-                    (*env)->DeleteGlobalRef(env, ctx->callback);
+                if (--ctx->refCount == 0) {
+                    // Reuse the node to carry the context to the free pass below.
+                    node->next = toFree;
+                    toFree = node;
+                    continue;
                 }
-                free(ctx);
             }
-
-            *current = toDelete->next;
-            free(toDelete);
-            // Continue scanning — do not break, so all matches are removed.
+            free(node);
+            // Continue scanning — all matches are removed.
         } else {
             current = &(*current)->next;
         }
     }
-
     pthread_mutex_unlock(&g_signerContextsMutex);
+
+    // Free outside the mutex; DeleteGlobalRef needs a JNI environment.
+    if (toFree != NULL) {
+        JNIEnv *env = get_jni_env();
+        while (toFree != NULL) {
+            SignerContextNode *next = toFree->next;
+            if (env != NULL && toFree->context->callback != NULL) {
+                (*env)->DeleteGlobalRef(env, toFree->context->callback);
+            }
+            free(toFree->context);
+            free(toFree);
+            toFree = next;
+        }
+    }
 }
 
 // Detach all context nodes keyed by a signer from the registry and return them
@@ -1593,11 +1737,7 @@ static void free_detached_contexts(JNIEnv *env, SignerContextNode *nodes) {
         SignerContextNode *next = nodes->next;
         JavaSignerContext *ctx = nodes->context;
         if (ctx != NULL) {
-            ctx->isActive = JNI_FALSE;
-            if (env != NULL && ctx->callback != NULL) {
-                (*env)->DeleteGlobalRef(env, ctx->callback);
-            }
-            free(ctx);
+            release_signer_context(env, ctx);
         }
         free(nodes);
         nodes = next;
@@ -1671,8 +1811,8 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromCallback(JNIE
         return 0;
     }
     
-    ctx->isActive = JNI_TRUE;
-    
+    ctx->refCount = 1;
+
     // Create the signer
     struct C2paSigner *signer = c2pa_signer_create(ctx, java_signer_callback, alg, ccerts, ctsaURL);
     
@@ -1933,18 +2073,16 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContext_cancelNative(JNIEnv
     return c2pa_context_cancel((struct C2paContext*)(uintptr_t)contextPtr);
 }
 
-// Frees a context callback (progress/HTTP-resolver) struct owned by a built context.
-// Called from C2PAContext.close() after the context itself has been freed.
+// Releases a context callback (progress/HTTP-resolver) struct owned by a built context.
+// Called from C2PAContext.close() after the context itself has been freed. A callback
+// invocation still in flight keeps the struct allocated until it completes.
 JNIEXPORT void JNICALL Java_org_contentauth_c2pa_C2PAContext_freeCallbackContextNative(JNIEnv *env, jclass clazz, jlong callbackPtr) {
     if (callbackPtr == 0) {
         return;
     }
     JavaContextCallback *jctx = (JavaContextCallback*)(uintptr_t)callbackPtr;
-    jctx->isActive = JNI_FALSE;
-    if (jctx->callback != NULL) {
-        (*env)->DeleteGlobalRef(env, jctx->callback);
-    }
-    free(jctx);
+    unregister_context_callback(jctx);
+    release_context_callback(env, jctx);
 }
 
 // Context builder methods
@@ -2009,7 +2147,14 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgress
         return 0;
     }
 
-    jctx->isActive = JNI_TRUE;
+    jctx->refCount = 1;
+    if (!register_context_callback(jctx)) {
+        (*env)->DeleteGlobalRef(env, jctx->callback);
+        free(jctx);
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
+                         "Failed to register progress callback");
+        return 0;
+    }
 
     int result = c2pa_context_builder_set_progress_callback(
         (struct C2paContextBuilder*)(uintptr_t)builderPtr,
@@ -2017,6 +2162,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgress
         java_progress_callback
     );
     if (result != 0) {
+        unregister_context_callback(jctx);
         (*env)->DeleteGlobalRef(env, jctx->callback);
         free(jctx);
         throw_c2pa_exception(env, "Failed to set progress callback");
@@ -2059,10 +2205,18 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setHttpReso
         return 0;
     }
 
-    jctx->isActive = JNI_TRUE;
+    jctx->refCount = 1;
+    if (!register_context_callback(jctx)) {
+        (*env)->DeleteGlobalRef(env, jctx->callback);
+        free(jctx);
+        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
+                         "Failed to register HTTP resolver");
+        return 0;
+    }
 
     struct C2paHttpResolver *resolver = c2pa_http_resolver_create(jctx, java_http_resolver_callback);
     if (resolver == NULL) {
+        unregister_context_callback(jctx);
         (*env)->DeleteGlobalRef(env, jctx->callback);
         free(jctx);
         throw_c2pa_exception(env, "Failed to create HTTP resolver");
@@ -2073,6 +2227,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setHttpReso
     if (result != 0) {
         // set_http_resolver only consumes the resolver on success; free it on failure.
         c2pa_free(resolver);
+        unregister_context_callback(jctx);
         (*env)->DeleteGlobalRef(env, jctx->callback);
         free(jctx);
         throw_c2pa_exception(env, "Failed to set HTTP resolver");

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -37,14 +37,17 @@ typedef struct {
 } JavaStreamContext;
 
 // Signer callback context. The core may invoke a callback with its user_data
-// pointer at any time until every object derived from the owning signer is
-// gone, and provides no destructor hook, so a trampoline must never
-// dereference the raw pointer it is handed. Instead, liveness is a registry
-// lookup: a context is invocable only while it is present in its registry, and
-// refCount (guarded by the registry mutex, one reference held by the registry
-// and one per in-flight invocation) defers the free until the last holder
-// releases. A stale pointer from the core is simply not found and ignored.
+// at any time until every object derived from the owning signer is gone, and
+// provides no destructor hook, so a trampoline must never treat what it is
+// handed as a pointer. The core is given an opaque id that is never reused, and
+// liveness is a registry lookup: a context is invocable only while an entry
+// with that id is present in its registry, and refCount (guarded by the
+// registry mutex, one reference held by the registry and one per in-flight
+// invocation) defers the free until the last holder releases. A stale id from
+// the core is simply not found and ignored, and can never alias a newer context
+// the way a recycled heap address could.
 typedef struct {
+    uintptr_t id;          // Opaque token handed to the core as user_data
     jobject callback;      // Global reference
     jmethodID signMethod;
     int refCount;
@@ -55,6 +58,7 @@ typedef struct {
 // released when that context is closed, with the same registry-lookup liveness
 // scheme as JavaSignerContext (under g_contextCallbacksMutex).
 typedef struct {
+    uintptr_t id;          // Opaque token handed to the core as user_data
     jobject callback;      // Global reference to the Kotlin bridge object
     jmethodID method;      // Cached bridge method id
     int refCount;
@@ -75,6 +79,18 @@ static SignerContextNode *g_signerContexts = NULL;
 static pthread_mutex_t g_signerContextsMutex = PTHREAD_MUTEX_INITIALIZER;
 static ContextCallbackNode *g_contextCallbacks = NULL;
 static pthread_mutex_t g_contextCallbacksMutex = PTHREAD_MUTEX_INITIALIZER;
+
+// Monotonic source of callback-context ids. Never reused for the lifetime of
+// the process; 0 is reserved so a NULL user_data never matches.
+static uintptr_t g_nextCallbackId = 1;
+static pthread_mutex_t g_callbackIdMutex = PTHREAD_MUTEX_INITIALIZER;
+
+static uintptr_t next_callback_id(void) {
+    pthread_mutex_lock(&g_callbackIdMutex);
+    uintptr_t id = g_nextCallbackId++;
+    pthread_mutex_unlock(&g_callbackIdMutex);
+    return id;
+}
 
 // JNI OnLoad - save JavaVM reference and cache IDs
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
@@ -466,17 +482,18 @@ static intptr_t java_flush_callback(struct StreamContext *context) {
     return (intptr_t)result;
 }
 
-// Acquire a signer context for a callback invocation. The pointer handed to us
-// by the core is only dereferenced after it has been found in the registry, so
-// a stale pointer for an already-released context is ignored rather than read.
-// Returns JNI_FALSE when not found. Must be paired with release_signer_context.
-static jboolean acquire_signer_context(JavaSignerContext *ctx) {
-    jboolean found = JNI_FALSE;
+// Acquire a signer context for a callback invocation. The token handed to us by
+// the core is an id, never a pointer; it is resolved through the registry, so a
+// stale id for an already-released context is not found and ignored. Returns
+// NULL when not found. Must be paired with release_signer_context.
+static JavaSignerContext *acquire_signer_context(const void *token) {
+    uintptr_t id = (uintptr_t)token;
+    JavaSignerContext *found = NULL;
     pthread_mutex_lock(&g_signerContextsMutex);
     for (SignerContextNode *node = g_signerContexts; node != NULL; node = node->next) {
-        if (node->context == ctx) {
-            ctx->refCount++;
-            found = JNI_TRUE;
+        if (node->context != NULL && node->context->id == id) {
+            node->context->refCount++;
+            found = node->context;
             break;
         }
     }
@@ -501,13 +518,14 @@ static void release_signer_context(JNIEnv *env, JavaSignerContext *ctx) {
 
 // Registry lookup acquire/release for context-builder callbacks, same scheme as
 // the signer context.
-static jboolean acquire_context_callback(JavaContextCallback *ctx) {
-    jboolean found = JNI_FALSE;
+static JavaContextCallback *acquire_context_callback(const void *token) {
+    uintptr_t id = (uintptr_t)token;
+    JavaContextCallback *found = NULL;
     pthread_mutex_lock(&g_contextCallbacksMutex);
     for (ContextCallbackNode *node = g_contextCallbacks; node != NULL; node = node->next) {
-        if (node->context == ctx) {
-            ctx->refCount++;
-            found = JNI_TRUE;
+        if (node->context->id == id) {
+            node->context->refCount++;
+            found = node->context;
             break;
         }
     }
@@ -616,8 +634,8 @@ static intptr_t java_signer_callback_invoke(JNIEnv *env, JavaSignerContext *jctx
 // Signer callback function
 static intptr_t java_signer_callback(const void *context, const unsigned char *data, uintptr_t len,
                                     unsigned char *signed_bytes, uintptr_t signed_len) {
-    JavaSignerContext *jctx = (JavaSignerContext*)context;
-    if (jctx == NULL || !acquire_signer_context(jctx)) {
+    JavaSignerContext *jctx = acquire_signer_context(context);
+    if (jctx == NULL) {
         return -1;
     }
 
@@ -634,8 +652,8 @@ static intptr_t java_signer_callback(const void *context, const unsigned char *d
 // Progress callback trampoline. The Kotlin side is a Void observer, so this always
 // returns 1 (continue) — cancellation is exposed separately via C2PAContext.cancel().
 static int java_progress_callback(const void *context, enum C2paProgressPhase phase, uint32_t step, uint32_t total) {
-    JavaContextCallback *jctx = (JavaContextCallback*)context;
-    if (jctx == NULL || !acquire_context_callback(jctx)) {
+    JavaContextCallback *jctx = acquire_context_callback(context);
+    if (jctx == NULL) {
         return 1;
     }
 
@@ -722,8 +740,8 @@ static int java_http_resolver_invoke(JNIEnv *env, JavaContextCallback *jctx,
 // Returns 0 on success, -1 on error (with c2pa_error_set_last set).
 static int java_http_resolver_callback(void *context, const struct C2paHttpRequest *request,
                                        struct C2paHttpResponse *response) {
-    JavaContextCallback *jctx = (JavaContextCallback*)context;
-    if (jctx == NULL || !acquire_context_callback(jctx)) {
+    JavaContextCallback *jctx = acquire_context_callback(context);
+    if (jctx == NULL) {
         c2pa_error_set_last("HTTP resolver is no longer active");
         return -1;
     }
@@ -1933,9 +1951,10 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromCallback(JNIE
     }
     
     ctx->refCount = 1;
+    ctx->id = next_callback_id();
 
-    // Create the signer
-    struct C2paSigner *signer = c2pa_signer_create(ctx, java_signer_callback, alg, ccerts, ctsaURL);
+    // Create the signer. The core receives the opaque id, not the struct pointer.
+    struct C2paSigner *signer = c2pa_signer_create((const void*)ctx->id, java_signer_callback, alg, ccerts, ctsaURL);
     
     release_cstring(env, certificateChain, ccerts);
     release_cstring(env, tsaURL, ctsaURL);
@@ -2269,6 +2288,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgress
     }
 
     jctx->refCount = 1;
+    jctx->id = next_callback_id();
     if (!register_context_callback(jctx)) {
         (*env)->DeleteGlobalRef(env, jctx->callback);
         free(jctx);
@@ -2277,9 +2297,10 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgress
         return 0;
     }
 
+    // The core receives the opaque id, not the struct pointer.
     int result = c2pa_context_builder_set_progress_callback(
         (struct C2paContextBuilder*)(uintptr_t)builderPtr,
-        jctx,
+        (const void*)jctx->id,
         java_progress_callback
     );
     if (result != 0) {
@@ -2327,6 +2348,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setHttpReso
     }
 
     jctx->refCount = 1;
+    jctx->id = next_callback_id();
     if (!register_context_callback(jctx)) {
         (*env)->DeleteGlobalRef(env, jctx->callback);
         free(jctx);
@@ -2335,7 +2357,8 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setHttpReso
         return 0;
     }
 
-    struct C2paHttpResolver *resolver = c2pa_http_resolver_create(jctx, java_http_resolver_callback);
+    // The core receives the opaque id, not the struct pointer.
+    struct C2paHttpResolver *resolver = c2pa_http_resolver_create((void*)jctx->id, java_http_resolver_callback);
     if (resolver == NULL) {
         unregister_context_callback(jctx);
         (*env)->DeleteGlobalRef(env, jctx->callback);

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -279,10 +279,16 @@ static JNIEnv* get_jni_env() {
 // pending while control returns into Rust: the FFI treats -1 as a recoverable error
 // and keeps calling JNI functions, which is undefined behavior with an exception
 // pending. Callbacks therefore clear and stash the throwable here, and the outer
-// JNI boundary rethrows it so callers see the app's real exception. Thread-local:
-// a callback stashes on the thread that runs it, and the boundary consumes it on
-// the same thread. A stash made on a Rust-spawned worker thread has no Java frame
-// to surface in and is dropped when the next stash or boundary clear replaces it.
+// JNI boundary rethrows it so callers see the app's real exception.
+//
+// Contract: a stash never outlives the JNI entry point whose FFI call produced
+// it. Every entry point that runs callbacks clears any leftover at entry and
+// calls finish_stashed_exception on every exit after the FFI call, which rethrows
+// the stash on failure and drops it on success. Entry points that do not run
+// callbacks never consult the stash. Thread-local: a callback stashes on the
+// thread that runs it, and the boundary consumes it on the same thread. A stash
+// made on a Rust-spawned worker thread has no Java frame to surface in; it is
+// dropped when the next stash on that thread replaces it.
 static __thread jthrowable g_stashedCallbackException = NULL;
 
 // Drops any exception stashed by a previous native call on this thread.
@@ -318,12 +324,22 @@ static int rethrow_stashed_exception(JNIEnv *env) {
     return 1;
 }
 
-// Helper to throw an exception with proper error message from C2PA
-static void throw_c2pa_exception(JNIEnv *env, const char *defaultMessage) {
-    // Prefer the app's own exception captured in a stream/signer/resolver callback.
-    if (rethrow_stashed_exception(env)) {
-        return;
+// Consumes the stash at the boundary that produced it. On failure the app's own
+// exception is rethrown so it takes precedence over the core's error string; on
+// success a stash left by a callback whose failure the core tolerated is dropped
+// rather than leaking into a later call. Returns 1 if an exception was thrown.
+static int finish_stashed_exception(JNIEnv *env, int failed) {
+    if (failed) {
+        return rethrow_stashed_exception(env);
     }
+    clear_stashed_exception(env);
+    return 0;
+}
+
+// Helper to throw an exception with proper error message from C2PA. Does not
+// consult the callback stash; boundaries that run callbacks rethrow it first via
+// finish_stashed_exception.
+static void throw_c2pa_exception(JNIEnv *env, const char *defaultMessage) {
     char *error = c2pa_error();
     if (error != NULL && strlen(error) > 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/RuntimeException"), error);
@@ -846,6 +862,9 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_fromStreamNative(JNIEnv
 
     release_cstring(env, format, cformat);
 
+    if (finish_stashed_exception(env, reader == NULL)) {
+        return 0;
+    }
     if (reader == NULL) {
         throw_c2pa_exception(env, "Failed to create reader from stream");
         return 0;
@@ -906,7 +925,10 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_fromManifestDataAndStre
 
     (*env)->ReleaseByteArrayElements(env, manifestData, data, JNI_ABORT);
     release_cstring(env, format, cformat);
-    
+
+    if (finish_stashed_exception(env, reader == NULL)) {
+        return 0;
+    }
     return (jlong)(uintptr_t)reader;
 }
 
@@ -1023,9 +1045,12 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_resourceToStreamNative(
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
     
     int64_t result = c2pa_reader_resource_to_stream(reader, curi, stream);
-    
+
     release_cstring(env, uri, curi);
-    
+
+    if (finish_stashed_exception(env, result < 0)) {
+        return -1;
+    }
     return (jlong)(uintptr_t)result;
 }
 
@@ -1075,6 +1100,9 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_nativeFromArchive(JNIE
         c2pa_free(ctx);
     }
 
+    if (finish_stashed_exception(env, builder == NULL)) {
+        return 0;
+    }
     if (builder == NULL) {
         throw_c2pa_exception(env, "Failed to create builder from archive");
         return 0;
@@ -1167,6 +1195,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addResourceNative(JNIEn
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
     int result = c2pa_builder_add_resource((struct C2paBuilder*)(uintptr_t)builderPtr, curi, stream);
     release_cstring(env, uri, curi);
+    finish_stashed_exception(env, result < 0);
     return result;
 }
 
@@ -1182,7 +1211,8 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromStream
     
     release_cstring(env, ingredientJson, cingredientJson);
     release_cstring(env, format, cformat);
-    
+
+    finish_stashed_exception(env, result < 0);
     return result;
 }
 
@@ -1190,7 +1220,9 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_toArchiveNative(JNIEnv 
     clear_stashed_exception(env);
     struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
-    return c2pa_builder_to_archive(builder, stream);
+    int result = c2pa_builder_to_archive(builder, stream);
+    finish_stashed_exception(env, result < 0);
+    return result;
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong streamPtr) {
@@ -1203,7 +1235,9 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromArchiv
 
     struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
-    return c2pa_builder_add_ingredient_from_archive(builder, stream);
+    int result = c2pa_builder_add_ingredient_from_archive(builder, stream);
+    finish_stashed_exception(env, result < 0);
+    return result;
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_writeIngredientArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring ingredientId, jlong streamPtr) {
@@ -1224,6 +1258,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_writeIngredientArchiveN
         (struct C2paBuilder*)(uintptr_t)builderPtr, cingredientId, stream
     );
     release_cstring(env, ingredientId, cingredientId);
+    finish_stashed_exception(env, result < 0);
     return result;
 }
 
@@ -1303,8 +1338,8 @@ JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signNative(JNIEnv *e
     // On failure, surface the app's own exception stashed by a stream/signer
     // callback if there is one; otherwise return NULL and let the Kotlin
     // wrapper raise C2PAError from c2pa_error().
+    finish_stashed_exception(env, size < 0);
     if (size < 0) {
-        rethrow_stashed_exception(env);
         return NULL;
     }
 
@@ -1337,8 +1372,8 @@ JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signWithContextNativ
     // On failure, surface the app's own exception stashed by a stream/signer
     // callback if there is one; otherwise return NULL and let the Kotlin
     // wrapper raise C2PAError from c2pa_error().
+    finish_stashed_exception(env, size < 0);
     if (size < 0) {
-        rethrow_stashed_exception(env);
         return NULL;
     }
 
@@ -1398,11 +1433,17 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signDataHashedEmb
     
     release_cstring(env, dataHash, cdataHash);
     release_cstring(env, format, cformat);
-    
+
+    if (finish_stashed_exception(env, size < 0 || manifestBytes == NULL)) {
+        if (manifestBytes != NULL) {
+            c2pa_free(manifestBytes);
+        }
+        return NULL;
+    }
     if (size < 0 || manifestBytes == NULL) {
         return NULL;
     }
-    
+
     jbyteArray result = (*env)->NewByteArray(env, size);
     (*env)->SetByteArrayRegion(env, result, 0, size, (const jbyte*)manifestBytes);
     c2pa_free(manifestBytes);
@@ -1428,6 +1469,12 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signEmbeddableNat
     int64_t size = c2pa_builder_sign_embeddable(builder, cformat, &manifestBytes);
     release_cstring(env, format, cformat);
 
+    if (finish_stashed_exception(env, size < 0 || manifestBytes == NULL)) {
+        if (manifestBytes != NULL) {
+            c2pa_free(manifestBytes);
+        }
+        return NULL;
+    }
     if (size < 0 || manifestBytes == NULL) {
         return NULL;
     }
@@ -1628,6 +1675,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_updateHashFromStreamNat
     );
 
     release_cstring(env, format, cformat);
+    finish_stashed_exception(env, result < 0);
     return result;
 }
 
@@ -2384,6 +2432,9 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withArchiveNative(JNIE
     // This consumes the old builder pointer
     struct C2paBuilder *newBuilder = c2pa_builder_with_archive(builder, stream);
 
+    if (finish_stashed_exception(env, newBuilder == NULL)) {
+        return 0;
+    }
     if (newBuilder == NULL) {
         throw_c2pa_exception(env, "Failed to set builder archive");
         return 0;
@@ -2431,6 +2482,9 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withStreamNative(JNIEnv
     struct C2paReader *newReader = c2pa_reader_with_stream(reader, cformat, stream);
     release_cstring(env, format, cformat);
 
+    if (finish_stashed_exception(env, newReader == NULL)) {
+        return 0;
+    }
     if (newReader == NULL) {
         throw_c2pa_exception(env, "Failed to configure reader with stream");
         return 0;
@@ -2460,6 +2514,9 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withFragmentNative(JNIE
     struct C2paReader *newReader = c2pa_reader_with_fragment(reader, cformat, stream, fragment);
     release_cstring(env, format, cformat);
 
+    if (finish_stashed_exception(env, newReader == NULL)) {
+        return 0;
+    }
     if (newReader == NULL) {
         throw_c2pa_exception(env, "Failed to configure reader with fragment");
         return 0;

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -275,8 +275,55 @@ static JNIEnv* get_jni_env() {
     return env;
 }
 
+// A Java exception raised inside a stream/signer/resolver callback cannot be left
+// pending while control returns into Rust: the FFI treats -1 as a recoverable error
+// and keeps calling JNI functions, which is undefined behavior with an exception
+// pending. Callbacks therefore clear and stash the throwable here, and the outer
+// JNI boundary rethrows it so callers see the app's real exception. Thread-local:
+// a callback stashes on the thread that runs it, and the boundary consumes it on
+// the same thread. A stash made on a Rust-spawned worker thread has no Java frame
+// to surface in and is dropped when the next stash or boundary clear replaces it.
+static __thread jthrowable g_stashedCallbackException = NULL;
+
+// Drops any exception stashed by a previous native call on this thread.
+static void clear_stashed_exception(JNIEnv *env) {
+    if (g_stashedCallbackException != NULL) {
+        (*env)->DeleteGlobalRef(env, g_stashedCallbackException);
+        g_stashedCallbackException = NULL;
+    }
+}
+
+// If a Java exception is pending, clears it and stashes it for the outer JNI
+// boundary. Returns 1 if an exception was pending.
+static int stash_pending_exception(JNIEnv *env) {
+    jthrowable pending = (*env)->ExceptionOccurred(env);
+    if (pending == NULL) {
+        return 0;
+    }
+    (*env)->ExceptionClear(env);
+    clear_stashed_exception(env);
+    g_stashedCallbackException = (jthrowable)(*env)->NewGlobalRef(env, pending);
+    (*env)->DeleteLocalRef(env, pending);
+    return 1;
+}
+
+// Rethrows the stashed callback exception, if any. Returns 1 if one was thrown.
+static int rethrow_stashed_exception(JNIEnv *env) {
+    if (g_stashedCallbackException == NULL) {
+        return 0;
+    }
+    (*env)->Throw(env, g_stashedCallbackException);
+    (*env)->DeleteGlobalRef(env, g_stashedCallbackException);
+    g_stashedCallbackException = NULL;
+    return 1;
+}
+
 // Helper to throw an exception with proper error message from C2PA
 static void throw_c2pa_exception(JNIEnv *env, const char *defaultMessage) {
+    // Prefer the app's own exception captured in a stream/signer/resolver callback.
+    if (rethrow_stashed_exception(env)) {
+        return;
+    }
     char *error = c2pa_error();
     if (error != NULL && strlen(error) > 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/RuntimeException"), error);
@@ -301,39 +348,41 @@ static jbyteArray safe_new_byte_array(JNIEnv *env, jsize size) {
     return array;
 }
 
-// Stream callbacks
+// Stream callbacks. Java exceptions are stashed rather than left pending, since
+// these return into Rust code that keeps making JNI calls after a -1.
 static intptr_t java_read_callback(struct StreamContext *context, uint8_t *data, intptr_t len) {
     JavaStreamContext *jctx = (JavaStreamContext*)context;
     JNIEnv *env = get_jni_env();
     if (env == NULL) {
         return -1;
     }
-    
+
     if (len > INT32_MAX) {
-        throw_c2pa_exception(env, "Requested buffer too large for JNI");
+        c2pa_error_set_last("Requested buffer too large for JNI");
         return -1;
     }
-    
+
     jbyteArray jdata = safe_new_byte_array(env, (jsize)len);
     if (jdata == NULL) {
+        stash_pending_exception(env);
         return -1;
     }
-    
+
     jlong result = (*env)->CallLongMethod(env, jctx->streamObject, g_streamReadMethod, jdata, (jlong)len);
-    if (check_exception(env)) {
+    if (stash_pending_exception(env)) {
         (*env)->DeleteLocalRef(env, jdata);
         return -1;
     }
-    
+
     if (result > 0 && result <= len) {
         (*env)->GetByteArrayRegion(env, jdata, 0, result, (jbyte*)data);
-        if (check_exception(env)) {
+        if (stash_pending_exception(env)) {
             (*env)->DeleteLocalRef(env, jdata);
             return -1;
         }
     }
     (*env)->DeleteLocalRef(env, jdata);
-    
+
     return (intptr_t)result;
 }
 
@@ -343,12 +392,12 @@ static intptr_t java_seek_callback(struct StreamContext *context, intptr_t offse
     if (env == NULL) {
         return -1;
     }
-    
+
     jlong result = (*env)->CallLongMethod(env, jctx->streamObject, g_streamSeekMethod, (jlong)offset, (jint)mode);
-    if (check_exception(env)) {
+    if (stash_pending_exception(env)) {
         return -1;
     }
-    
+
     return (intptr_t)result;
 }
 
@@ -358,29 +407,30 @@ static intptr_t java_write_callback(struct StreamContext *context, const uint8_t
     if (env == NULL) {
         return -1;
     }
-    
+
     if (len > INT32_MAX) {
-        throw_c2pa_exception(env, "Requested buffer too large for JNI");
+        c2pa_error_set_last("Requested buffer too large for JNI");
         return -1;
     }
-    
+
     jbyteArray jdata = safe_new_byte_array(env, (jsize)len);
     if (jdata == NULL) {
+        stash_pending_exception(env);
         return -1;
     }
-    
+
     (*env)->SetByteArrayRegion(env, jdata, 0, len, (const jbyte*)data);
-    if (check_exception(env)) {
+    if (stash_pending_exception(env)) {
         (*env)->DeleteLocalRef(env, jdata);
         return -1;
     }
-    
+
     jlong result = (*env)->CallLongMethod(env, jctx->streamObject, g_streamWriteMethod, jdata, (jlong)len);
-    if (check_exception(env)) {
+    if (stash_pending_exception(env)) {
         (*env)->DeleteLocalRef(env, jdata);
         return -1;
     }
-    
+
     (*env)->DeleteLocalRef(env, jdata);
     return (intptr_t)result;
 }
@@ -391,12 +441,12 @@ static intptr_t java_flush_callback(struct StreamContext *context) {
     if (env == NULL) {
         return -1;
     }
-    
+
     jlong result = (*env)->CallLongMethod(env, jctx->streamObject, g_streamFlushMethod);
-    if (check_exception(env)) {
+    if (stash_pending_exception(env)) {
         return -1;
     }
-    
+
     return (intptr_t)result;
 }
 
@@ -502,46 +552,47 @@ static intptr_t java_signer_callback_invoke(JNIEnv *env, JavaSignerContext *jctx
                                             unsigned char *signed_bytes, uintptr_t signed_len) {
     // Create byte array from data
     if (len > INT32_MAX) {
-        throw_c2pa_exception(env, "Requested buffer too large for JNI");
+        c2pa_error_set_last("Requested buffer too large for JNI");
         return -1;
     }
-    
+
     jbyteArray jdata = safe_new_byte_array(env, (jsize)len);
     if (jdata == NULL) {
+        stash_pending_exception(env);
         return -1;
     }
-    
+
     (*env)->SetByteArrayRegion(env, jdata, 0, len, (const jbyte*)data);
-    if (check_exception(env)) {
+    if (stash_pending_exception(env)) {
         (*env)->DeleteLocalRef(env, jdata);
         return -1;
     }
-    
+
     // Call the sign method
     jbyteArray jsignature = (jbyteArray)(*env)->CallObjectMethod(env, jctx->callback, jctx->signMethod, jdata);
     (*env)->DeleteLocalRef(env, jdata);
-    
-    if (check_exception(env)) {
+
+    if (stash_pending_exception(env)) {
         return -1;
     }
-    
+
     if (jsignature == NULL) {
         return -1;
     }
-    
+
     // Get signature data
     jsize sig_len = (*env)->GetArrayLength(env, jsignature);
     if (sig_len > signed_len) {
         (*env)->DeleteLocalRef(env, jsignature);
         return -1;
     }
-    
+
     (*env)->GetByteArrayRegion(env, jsignature, 0, sig_len, (jbyte*)signed_bytes);
-    if (check_exception(env)) {
+    if (stash_pending_exception(env)) {
         (*env)->DeleteLocalRef(env, jsignature);
         return -1;
     }
-    
+
     (*env)->DeleteLocalRef(env, jsignature);
     return sig_len;
 }
@@ -576,6 +627,8 @@ static int java_progress_callback(const void *context, enum C2paProgressPhase ph
     if (env != NULL) {
         // Bridge signature: onProgress(int phase, long step, long total) -> void
         (*env)->CallVoidMethod(env, jctx->callback, jctx->method, (jint)phase, (jlong)step, (jlong)total);
+        // The observer must not affect the operation, so its exceptions are
+        // logged and dropped rather than stashed for the outer boundary.
         check_exception(env);
     }
 
@@ -605,7 +658,7 @@ static int java_http_resolver_invoke(JNIEnv *env, JavaContextCallback *jctx,
     if (jheaders != NULL) (*env)->DeleteLocalRef(env, jheaders);
     if (jbody != NULL) (*env)->DeleteLocalRef(env, jbody);
 
-    if (check_exception(env) || jresp == NULL) {
+    if (stash_pending_exception(env) || jresp == NULL) {
         c2pa_error_set_last("HTTP resolver callback failed");
         return -1;
     }
@@ -764,6 +817,7 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_Stream_releaseStreamNative(JNIE
 
 // Reader native methods
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_fromStreamNative(JNIEnv *env, jclass clazz, jstring format, jlong streamPtr) {
+    clear_stashed_exception(env);
     if (format == NULL || streamPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
                          "Format and stream cannot be null");
@@ -801,6 +855,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_fromStreamNative(JNIEnv
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_fromManifestDataAndStreamNative(JNIEnv *env, jclass clazz, jstring format, jlong streamPtr, jbyteArray manifestData) {
+    clear_stashed_exception(env);
     if (format == NULL || streamPtr == 0 || manifestData == NULL) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
                          "Format, stream, and manifest data cannot be null");
@@ -952,6 +1007,7 @@ JNIEXPORT jboolean JNICALL Java_org_contentauth_c2pa_Reader_isEmbeddedNative(JNI
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_resourceToStreamNative(JNIEnv *env, jobject obj, jlong readerPtr, jstring uri, jlong streamPtr) {
+    clear_stashed_exception(env);
     if (readerPtr == 0 || uri == NULL || streamPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
                          "Reader, URI, and stream cannot be null");
@@ -997,6 +1053,7 @@ JNIEXPORT jobjectArray JNICALL Java_org_contentauth_c2pa_Builder_supportedMimeTy
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_nativeFromArchive(JNIEnv *env, jclass clazz, jlong streamPtr) {
+    clear_stashed_exception(env);
     if (streamPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
                          "Stream cannot be null");
@@ -1105,6 +1162,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setBasePathNative(JNIEn
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addResourceNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring uri, jlong streamPtr) {
+    clear_stashed_exception(env);
     const char *curi = jstring_to_cstring(env, uri);
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
     int result = c2pa_builder_add_resource((struct C2paBuilder*)(uintptr_t)builderPtr, curi, stream);
@@ -1113,6 +1171,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addResourceNative(JNIEn
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromStreamNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring ingredientJson, jstring format, jlong streamPtr) {
+    clear_stashed_exception(env);
     const char *cingredientJson = jstring_to_cstring(env, ingredientJson);
     const char *cformat = jstring_to_cstring(env, format);
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
@@ -1128,12 +1187,14 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromStream
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_toArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong streamPtr) {
+    clear_stashed_exception(env);
     struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
     return c2pa_builder_to_archive(builder, stream);
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong streamPtr) {
+    clear_stashed_exception(env);
     if (builderPtr == 0 || streamPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
                          "Builder and stream cannot be null");
@@ -1146,6 +1207,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromArchiv
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_writeIngredientArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring ingredientId, jlong streamPtr) {
+    clear_stashed_exception(env);
     if (builderPtr == 0 || ingredientId == NULL || streamPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
                          "Builder, ingredient id, and stream cannot be null");
@@ -1216,6 +1278,7 @@ static jobject build_sign_result(JNIEnv *env, int64_t size, const unsigned char 
 }
 
 JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong sourceStreamPtr, jlong destStreamPtr, jlong signerPtr) {
+    clear_stashed_exception(env);
     if (builderPtr == 0 || format == NULL || sourceStreamPtr == 0 || destStreamPtr == 0 || signerPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
                          "Builder, format, streams, and signer cannot be null");
@@ -1237,8 +1300,11 @@ JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signNative(JNIEnv *e
     
     release_cstring(env, format, cformat);
 
-    // On failure, return NULL and let the Kotlin wrapper raise C2PAError from c2pa_error().
+    // On failure, surface the app's own exception stashed by a stream/signer
+    // callback if there is one; otherwise return NULL and let the Kotlin
+    // wrapper raise C2PAError from c2pa_error().
     if (size < 0) {
+        rethrow_stashed_exception(env);
         return NULL;
     }
 
@@ -1246,6 +1312,7 @@ JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signNative(JNIEnv *e
 }
 
 JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signWithContextNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong sourceStreamPtr, jlong destStreamPtr) {
+    clear_stashed_exception(env);
     if (builderPtr == 0 || format == NULL || sourceStreamPtr == 0 || destStreamPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
                          "Builder, format, and streams cannot be null");
@@ -1267,8 +1334,11 @@ JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signWithContextNativ
 
     release_cstring(env, format, cformat);
 
-    // On failure, return NULL and let the Kotlin wrapper raise C2PAError from c2pa_error().
+    // On failure, surface the app's own exception stashed by a stream/signer
+    // callback if there is one; otherwise return NULL and let the Kotlin
+    // wrapper raise C2PAError from c2pa_error().
     if (size < 0) {
+        rethrow_stashed_exception(env);
         return NULL;
     }
 
@@ -1316,6 +1386,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_dataHashedPlaceho
 }
 
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signDataHashedEmbeddableNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong signerPtr, jstring dataHash, jstring format, jlong assetPtr) {
+    clear_stashed_exception(env);
     struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
     struct C2paSigner *signer = (struct C2paSigner*)(uintptr_t)signerPtr;
     const char *cdataHash = jstring_to_cstring(env, dataHash);
@@ -1340,6 +1411,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signDataHashedEmb
 }
 
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signEmbeddableNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
+    clear_stashed_exception(env);
     if (builderPtr == 0 || format == NULL) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
                          "Builder and format cannot be null");
@@ -1537,6 +1609,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_hashMdatBytesNative(JNI
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_updateHashFromStreamNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong streamPtr) {
+    clear_stashed_exception(env);
     if (builderPtr == 0 || format == NULL || streamPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
                          "Builder, format, and stream cannot be null");
@@ -2298,6 +2371,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withDefinitionNative(J
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong streamPtr) {
+    clear_stashed_exception(env);
     if (builderPtr == 0 || streamPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
                          "Builder and stream cannot be null");
@@ -2338,6 +2412,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_nativeFromContext(JNIEn
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withStreamNative(JNIEnv *env, jobject obj, jlong readerPtr, jstring format, jlong streamPtr) {
+    clear_stashed_exception(env);
     if (readerPtr == 0 || format == NULL || streamPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
                          "Reader, format, and stream cannot be null");
@@ -2365,6 +2440,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withStreamNative(JNIEnv
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withFragmentNative(JNIEnv *env, jobject obj, jlong readerPtr, jstring format, jlong streamPtr, jlong fragmentPtr) {
+    clear_stashed_exception(env);
     if (readerPtr == 0 || format == NULL || streamPtr == 0 || fragmentPtr == 0) {
         (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
                          "Reader, format, stream, and fragment cannot be null");

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -175,6 +175,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     val streamTests = AppStreamTests(context)
     results.add(streamTests.testStreamOperations())
     results.add(streamTests.testStreamExceptionPropagation())
+    results.add(streamTests.testStreamWriteExceptionPropagation())
     results.add(streamTests.testStreamFileOptions())
     results.add(streamTests.testWriteOnlyStreams())
     results.add(streamTests.testCustomStreamCallbacks())

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -174,6 +174,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     // Stream Tests
     val streamTests = AppStreamTests(context)
     results.add(streamTests.testStreamOperations())
+    results.add(streamTests.testStreamExceptionPropagation())
     results.add(streamTests.testStreamFileOptions())
     results.add(streamTests.testWriteOnlyStreams())
     results.add(streamTests.testCustomStreamCallbacks())

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -200,6 +200,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBmffMerkleHashing())
     results.add(builderTests.testBuilderEmbeddableErrorPaths())
     results.add(builderTests.testContextProgressCallback())
+    results.add(builderTests.testContextCloseDuringSign())
     results.add(builderTests.testContextHttpResolver())
     results.add(builderTests.testContextHttpResolverOkHttp())
     results.add(builderTests.testContextHttpResolverRemoteFetch())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -42,7 +42,10 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 import java.util.UUID
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
 
 /** BuilderTests - Builder API tests for manifest creation */
 abstract class BuilderTests : TestBase() {
@@ -931,6 +934,81 @@ abstract class BuilderTests : TestBase() {
                 )
             } catch (e: C2PAError) {
                 TestResult("Context Progress Callback", false, "Progress callback flow threw", e.toString())
+            }
+        }
+    }
+
+    suspend fun testContextCloseDuringSign(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Context Close During Sign") {
+            try {
+                val certPem = loadResourceAsString("es256_certs")
+                val keyPem = loadResourceAsString("es256_private")
+                val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+                val settingsJson =
+                    """{"version": 1, "builder": {"created_assertion_labels": ["c2pa.actions"]}}"""
+
+                // Block the first progress callback until the context has been closed on
+                // this thread, so the close races an in-flight callback invocation. The
+                // callback boxes must stay alive until the invocation returns.
+                val firstUpdate = CountDownLatch(1)
+                val contextClosed = CountDownLatch(1)
+                val updateCount = AtomicInteger(0)
+
+                val context = C2PASettings.create().use { settings ->
+                    settings.updateFromString(settingsJson, "json")
+                    C2PAContextBuilder.create()
+                        .setSettings(settings)
+                        .setProgressCallback {
+                            if (updateCount.incrementAndGet() == 1) {
+                                firstUpdate.countDown()
+                                contextClosed.await(10, TimeUnit.SECONDS)
+                            }
+                        }
+                        .build()
+                }
+
+                var signedSize = -1L
+                var signError: Exception? = null
+                val builder = Builder.fromContext(context).withDefinition(TEST_MANIFEST_JSON)
+                val signThread = thread {
+                    try {
+                        ByteArrayStream(sourceImageData).use { source ->
+                            ByteArrayStream().use { dest ->
+                                Signer.fromInfo(SignerInfo(SigningAlgorithm.ES256, certPem, keyPem)).use { signer ->
+                                    signedSize = builder.sign("image/jpeg", source, dest, signer).size
+                                }
+                            }
+                        }
+                    } catch (e: Exception) {
+                        signError = e
+                    }
+                }
+
+                val callbackSeen = firstUpdate.await(10, TimeUnit.SECONDS)
+                if (callbackSeen) {
+                    context.close()
+                }
+                contextClosed.countDown()
+                signThread.join(20000)
+                builder.close()
+                if (!callbackSeen) {
+                    context.close()
+                }
+
+                val success = callbackSeen && !signThread.isAlive && signError == null && signedSize > 0
+                TestResult(
+                    "Context Close During Sign",
+                    success,
+                    if (success) {
+                        "Context closed during an in-flight callback without disturbing the sign"
+                    } else {
+                        "Close-during-sign race failed"
+                    },
+                    "Callback seen: $callbackSeen, updates: ${updateCount.get()}, " +
+                        "signed size: $signedSize, error: $signError",
+                )
+            } catch (e: Exception) {
+                TestResult("Context Close During Sign", false, "Close-during-sign flow threw", e.toString())
             }
         }
     }

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/StreamTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/StreamTests.kt
@@ -88,6 +88,54 @@ abstract class StreamTests : TestBase() {
         }
     }
 
+    suspend fun testStreamWriteExceptionPropagation(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Stream Write Exception Propagation") {
+            // The write path through a result-code entry point (toArchive) must surface
+            // the callback's exception as itself, and the exception must not linger:
+            // an unrelated failure on the same thread afterwards must raise its own
+            // error, not the stream's.
+            val marker = "write deliberately broken"
+            var archiveThrown: Throwable? = null
+            var laterThrown: Throwable? = null
+
+            Builder.fromJson(TEST_MANIFEST_JSON).use { builder ->
+                CallbackStream(
+                    writer = { _, _ -> throw IOException(marker) },
+                    seeker = { _, _ -> 0L },
+                    flusher = { 0 },
+                ).use { dest ->
+                    try {
+                        builder.toArchive(dest)
+                    } catch (e: Throwable) {
+                        archiveThrown = e
+                    }
+                }
+            }
+
+            Builder.fromJson(TEST_MANIFEST_JSON).use { builder ->
+                try {
+                    builder.withDefinition("{ not valid json")
+                } catch (e: Throwable) {
+                    laterThrown = e
+                }
+            }
+
+            val propagated = archiveThrown is IOException && archiveThrown?.message == marker
+            val isolated = laterThrown != null && laterThrown !is IOException
+            val success = propagated && isolated
+            TestResult(
+                "Stream Write Exception Propagation",
+                success,
+                when {
+                    success -> "toArchive surfaced the IOException and it did not leak into the next call"
+                    !propagated -> "Expected the writer's IOException from toArchive, got: $archiveThrown"
+                    else -> "Stale stream exception leaked into an unrelated call: $laterThrown"
+                },
+                "toArchive threw: $archiveThrown\nwithDefinition threw: $laterThrown",
+            )
+        }
+    }
+
     suspend fun testStreamFileOptions(): TestResult = withContext(Dispatchers.IO) {
         runTest("Stream File Options") {
             val tempFile =

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/StreamTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/StreamTests.kt
@@ -24,6 +24,7 @@ import org.contentauth.c2pa.Reader
 import org.contentauth.c2pa.SeekMode
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.IOException
 
 /** StreamTests - Stream operations and I/O tests */
 abstract class StreamTests : TestBase() {
@@ -51,6 +52,39 @@ abstract class StreamTests : TestBase() {
                     )
                 }
             }
+        }
+    }
+
+    suspend fun testStreamExceptionPropagation(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Stream Exception Propagation") {
+            // An exception thrown by a stream callback must surface to the caller as
+            // itself, not as a generic error, and must not be left pending while the
+            // native operation keeps running.
+            val marker = "stream deliberately broken"
+            var thrown: Throwable? = null
+
+            CallbackStream(
+                reader = { _, _ -> throw IOException(marker) },
+                seeker = { _, _ -> 0L },
+            ).use { stream ->
+                try {
+                    Reader.fromStream("image/jpeg", stream).use { }
+                } catch (e: Throwable) {
+                    thrown = e
+                }
+            }
+
+            val success = thrown is IOException && thrown?.message == marker
+            TestResult(
+                "Stream Exception Propagation",
+                success,
+                if (success) {
+                    "Stream callback exception surfaced as the original IOException"
+                } else {
+                    "Expected the callback's IOException, got: $thrown"
+                },
+                "Thrown: $thrown",
+            )
         }
     }
 


### PR DESCRIPTION
## Changes in this pull request
<!-- Give a description of what has changed -->
Fixes two races in the JNI callback layer: callback contexts are now registry-tracked and reference-counted, so closing a signer or context during an in-flight operation can no longer touch freed memory. Java exceptions thrown inside stream and signer callbacks are stashed and rethrown at the JNI boundary instead of being left pending inside Rust or swallowed behind a generic RuntimeException.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment