### PR TITLE
Fix: JNI boundary correctness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,14 @@ jobs:
         api-level: [33, 35]
         target: [google_apis]
         arch: [x86_64]
+        include:
+          # 32-bit ABI run at the library's minSdk. The JNI bridge ships
+          # armeabi-v7a and x86 and has pointer-width-dependent code (int64
+          # results, usize parameters), and no other job runs at the minimum
+          # supported level. 32-bit x86 google_apis images exist for 28-30.
+          - api-level: 28
+            target: google_apis
+            arch: x86
 
     steps:
       - name: Checkout
@@ -95,14 +103,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.api-level }}
+          name: test-results-${{ matrix.api-level }}-${{ matrix.arch }}
           path: library/build/reports/androidTests/
 
       - name: Upload coverage reports to GitHub
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-reports-${{ matrix.api-level }}
+          name: coverage-reports-${{ matrix.api-level }}-${{ matrix.arch }}
           path: |
             library/build/reports/jacoco/jacocoInstrumentedTestReport/
             library/build/reports/coverage/androidTest/debug/connected/

--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -172,6 +172,12 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestClosedHandleValidation() = runBlocking {
+        val result = testClosedHandleValidation()
+        assertTrue(result.success, "Closed Handle Validation test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestContextCloseDuringSign() = runBlocking {
         val result = testContextCloseDuringSign()
         assertTrue(result.success, "Context Close During Sign test failed: ${result.message}")

--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidCoreTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidCoreTests.kt
@@ -70,6 +70,12 @@ class AndroidCoreTests : CoreTests() {
     }
 
     @Test
+    fun runTestReaderResourceErrorHandling() = runBlocking {
+        val result = testReaderResourceErrorHandling()
+        assertTrue(result.success, "Reader Resource Error Handling test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestLoadSettings() = runBlocking {
         val result = testLoadSettings()
         assertTrue(result.success, "Load Settings test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -352,19 +352,6 @@ static int finish_stashed_exception(JNIEnv *env, int failed) {
     return 0;
 }
 
-// Helper to throw an exception with proper error message from C2PA. Does not
-// consult the callback stash; boundaries that run callbacks rethrow it first via
-// finish_stashed_exception.
-static void throw_c2pa_exception(JNIEnv *env, const char *defaultMessage) {
-    char *error = c2pa_error();
-    if (error != NULL && strlen(error) > 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/RuntimeException"), error);
-        c2pa_free(error);
-    } else {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/RuntimeException"), defaultMessage);
-    }
-}
-
 // Helper for safe array allocation with error handling
 static jbyteArray safe_new_byte_array(JNIEnv *env, jsize size) {
     if (size < 0) {
@@ -880,11 +867,8 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_fromStreamNative(JNIEnv
 
     release_cstring(env, format, cformat);
 
-    if (finish_stashed_exception(env, reader == NULL)) {
-        return 0;
-    }
+    finish_stashed_exception(env, reader == NULL);
     if (reader == NULL) {
-        throw_c2pa_exception(env, "Failed to create reader from stream");
         return 0;
     }
 
@@ -967,7 +951,6 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_toJsonNative(JNIEnv *
     char *json = c2pa_reader_json(reader);
     
     if (json == NULL) {
-        throw_c2pa_exception(env, "Failed to generate JSON from reader");
         return NULL;
     }
     
@@ -987,7 +970,6 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_toDetailedJsonNative(
     char *json = c2pa_reader_detailed_json(reader);
     
     if (json == NULL) {
-        throw_c2pa_exception(env, "Failed to generate detailed JSON from reader");
         return NULL;
     }
     
@@ -1007,7 +989,6 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_crjsonNative(JNIEnv *
     char *json = c2pa_reader_crjson(reader);
 
     if (json == NULL) {
-        throw_c2pa_exception(env, "Failed to generate crJSON from reader");
         return NULL;
     }
 
@@ -1118,11 +1099,8 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_nativeFromArchive(JNIE
         c2pa_free(ctx);
     }
 
-    if (finish_stashed_exception(env, builder == NULL)) {
-        return 0;
-    }
+    finish_stashed_exception(env, builder == NULL);
     if (builder == NULL) {
-        throw_c2pa_exception(env, "Failed to create builder from archive");
         return 0;
     }
 
@@ -1418,7 +1396,6 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_dataHashedPlaceho
     release_cstring(env, format, cformat);
     
     if (size < 0 || manifestBytes == NULL) {
-        throw_c2pa_exception(env, "Failed to create data hashed placeholder");
         return NULL;
     }
     
@@ -2307,7 +2284,6 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgress
         unregister_context_callback(jctx);
         (*env)->DeleteGlobalRef(env, jctx->callback);
         free(jctx);
-        throw_c2pa_exception(env, "Failed to set progress callback");
         return 0;
     }
 
@@ -2363,7 +2339,6 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setHttpReso
         unregister_context_callback(jctx);
         (*env)->DeleteGlobalRef(env, jctx->callback);
         free(jctx);
-        throw_c2pa_exception(env, "Failed to create HTTP resolver");
         return 0;
     }
 
@@ -2374,7 +2349,6 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setHttpReso
         unregister_context_callback(jctx);
         (*env)->DeleteGlobalRef(env, jctx->callback);
         free(jctx);
-        throw_c2pa_exception(env, "Failed to set HTTP resolver");
         return 0;
     }
 
@@ -2409,7 +2383,6 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_nativeFromContext(JNIE
     struct C2paBuilder *builder = c2pa_builder_from_context(context);
 
     if (builder == NULL) {
-        throw_c2pa_exception(env, "Failed to create builder from context");
         return 0;
     }
 
@@ -2434,7 +2407,6 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withDefinitionNative(J
     release_cstring(env, manifestJson, cmanifestJson);
 
     if (newBuilder == NULL) {
-        throw_c2pa_exception(env, "Failed to set builder definition");
         return 0;
     }
 
@@ -2455,11 +2427,8 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withArchiveNative(JNIE
     // This consumes the old builder pointer
     struct C2paBuilder *newBuilder = c2pa_builder_with_archive(builder, stream);
 
-    if (finish_stashed_exception(env, newBuilder == NULL)) {
-        return 0;
-    }
+    finish_stashed_exception(env, newBuilder == NULL);
     if (newBuilder == NULL) {
-        throw_c2pa_exception(env, "Failed to set builder archive");
         return 0;
     }
 
@@ -2478,7 +2447,6 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_nativeFromContext(JNIEn
     struct C2paReader *reader = c2pa_reader_from_context(context);
 
     if (reader == NULL) {
-        throw_c2pa_exception(env, "Failed to create reader from context");
         return 0;
     }
 
@@ -2505,11 +2473,8 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withStreamNative(JNIEnv
     struct C2paReader *newReader = c2pa_reader_with_stream(reader, cformat, stream);
     release_cstring(env, format, cformat);
 
-    if (finish_stashed_exception(env, newReader == NULL)) {
-        return 0;
-    }
+    finish_stashed_exception(env, newReader == NULL);
     if (newReader == NULL) {
-        throw_c2pa_exception(env, "Failed to configure reader with stream");
         return 0;
     }
 
@@ -2537,11 +2502,8 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withFragmentNative(JNIE
     struct C2paReader *newReader = c2pa_reader_with_fragment(reader, cformat, stream, fragment);
     release_cstring(env, format, cformat);
 
-    if (finish_stashed_exception(env, newReader == NULL)) {
-        return 0;
-    }
+    finish_stashed_exception(env, newReader == NULL);
     if (newReader == NULL) {
-        throw_c2pa_exception(env, "Failed to configure reader with fragment");
         return 0;
     }
 

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -1473,7 +1473,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_dataHashedPlaceho
         return NULL;
     }
     
-    if (reservedSize < 0 || (uint64_t)reservedSize != (uint64_t)(uintptr_t)reservedSize) {
+    if ((uint64_t)reservedSize != (uint64_t)(uintptr_t)reservedSize) {
         throw_checked(env, "java/lang/IllegalArgumentException", "Reserved size out of range");
         return NULL;
     }

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -386,6 +386,17 @@ static jbyteArray safe_new_byte_array(JNIEnv *env, jsize size) {
     return array;
 }
 
+// Allocates a byte array for an int64 FFI size. jsize is 32-bit, so sizes that
+// do not fit a Java array are rejected instead of silently truncated.
+static jbyteArray new_byte_array_for_size(JNIEnv *env, int64_t size) {
+    if (size < 0 || size > INT32_MAX) {
+        throw_checked(env, "java/lang/IllegalArgumentException",
+                      "Native buffer size exceeds Java array limit");
+        return NULL;
+    }
+    return safe_new_byte_array(env, (jsize)size);
+}
+
 // Stream callbacks. Java exceptions are stashed rather than left pending, since
 // these return into Rust code that keeps making JNI calls after a -1.
 static intptr_t java_read_callback(struct StreamContext *context, uint8_t *data, intptr_t len) {
@@ -1066,7 +1077,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_resourceToStreamNative(
     if (finish_stashed_exception(env, result < 0)) {
         return -1;
     }
-    return (jlong)(uintptr_t)result;
+    return (jlong)result;
 }
 
 JNIEXPORT jobjectArray JNICALL Java_org_contentauth_c2pa_Reader_supportedMimeTypesNative(JNIEnv *env, jclass clazz) {
@@ -1318,13 +1329,13 @@ static jobject build_sign_result(JNIEnv *env, int64_t size, const unsigned char 
 
     jbyteArray jmanifestBytes = NULL;
     if (manifestBytes != NULL && size > 0) {
-        jmanifestBytes = safe_new_byte_array(env, size);
+        jmanifestBytes = new_byte_array_for_size(env, size);
         if (jmanifestBytes == NULL) {
             c2pa_free(manifestBytes);
             return NULL;
         }
 
-        (*env)->SetByteArrayRegion(env, jmanifestBytes, 0, size, (const jbyte*)manifestBytes);
+        (*env)->SetByteArrayRegion(env, jmanifestBytes, 0, (jsize)size, (const jbyte*)manifestBytes);
         if (check_exception(env)) {
             c2pa_free(manifestBytes);
             return NULL;
@@ -1415,6 +1426,11 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_dataHashedPlaceho
         return NULL;
     }
     
+    if (reservedSize < 0 || (uint64_t)reservedSize != (uint64_t)(uintptr_t)reservedSize) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Reserved size out of range");
+        return NULL;
+    }
+
     struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
     const char *cformat = jstring_to_cstring(env, format);
     if (cformat == NULL) {
@@ -1430,13 +1446,13 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_dataHashedPlaceho
         return NULL;
     }
     
-    jbyteArray result = safe_new_byte_array(env, size);
+    jbyteArray result = new_byte_array_for_size(env, size);
     if (result == NULL) {
         c2pa_free(manifestBytes);
         return NULL;
     }
     
-    (*env)->SetByteArrayRegion(env, result, 0, size, (const jbyte*)manifestBytes);
+    (*env)->SetByteArrayRegion(env, result, 0, (jsize)size, (const jbyte*)manifestBytes);
     if (check_exception(env)) {
         c2pa_free(manifestBytes);
         return NULL;
@@ -1480,7 +1496,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signDataHashedEmb
         return NULL;
     }
 
-    jbyteArray result = safe_new_byte_array(env, (jsize)size);
+    jbyteArray result = new_byte_array_for_size(env, size);
     if (result == NULL) {
         c2pa_free(manifestBytes);
         return NULL;
@@ -1518,12 +1534,12 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signEmbeddableNat
         return NULL;
     }
 
-    jbyteArray result = safe_new_byte_array(env, size);
+    jbyteArray result = new_byte_array_for_size(env, size);
     if (result == NULL) {
         c2pa_free(manifestBytes);
         return NULL;
     }
-    (*env)->SetByteArrayRegion(env, result, 0, size, (const jbyte*)manifestBytes);
+    (*env)->SetByteArrayRegion(env, result, 0, (jsize)size, (const jbyte*)manifestBytes);
     if (check_exception(env)) {
         c2pa_free(manifestBytes);
         return NULL;
@@ -1552,12 +1568,12 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_placeholderNative
         return NULL;
     }
 
-    jbyteArray result = safe_new_byte_array(env, size);
+    jbyteArray result = new_byte_array_for_size(env, size);
     if (result == NULL) {
         c2pa_free(manifestBytes);
         return NULL;
     }
-    (*env)->SetByteArrayRegion(env, result, 0, size, (const jbyte*)manifestBytes);
+    (*env)->SetByteArrayRegion(env, result, 0, (jsize)size, (const jbyte*)manifestBytes);
     if (check_exception(env)) {
         c2pa_free(manifestBytes);
         return NULL;
@@ -1640,12 +1656,12 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_formatEmbeddableN
         return NULL;
     }
 
-    jbyteArray result = safe_new_byte_array(env, size);
+    jbyteArray result = new_byte_array_for_size(env, size);
     if (result == NULL) {
         c2pa_free(resultBytes);
         return NULL;
     }
-    (*env)->SetByteArrayRegion(env, result, 0, size, (const jbyte*)resultBytes);
+    (*env)->SetByteArrayRegion(env, result, 0, (jsize)size, (const jbyte*)resultBytes);
     if (check_exception(env)) {
         c2pa_free(resultBytes);
         return NULL;
@@ -1659,6 +1675,10 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setFixedSizeMerkleNativ
         throw_checked(env, "java/lang/IllegalArgumentException", "Builder cannot be null");
         return -1;
     }
+    if (fixedSizeKb < 0 || (uint64_t)fixedSizeKb != (uint64_t)(uintptr_t)fixedSizeKb) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Fixed chunk size out of range");
+        return -1;
+    }
     return c2pa_builder_set_fixed_size_merkle((struct C2paBuilder*)(uintptr_t)builderPtr, (uintptr_t)fixedSizeKb);
 }
 
@@ -1669,6 +1689,11 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_hashMdatBytesNative(JNI
     }
 
     jsize dataLen = (*env)->GetArrayLength(env, data);
+    if (mdatId < 0 || (uint64_t)mdatId != (uint64_t)(uintptr_t)mdatId) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "mdat id out of range");
+        return -1;
+    }
+
     jbyte *dataPtr = (*env)->GetByteArrayElements(env, data, NULL);
     if (dataPtr == NULL) {
         check_exception(env);

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -103,26 +103,33 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         return JNI_ERR;
     }
     
-    // Cache frequently used classes and methods
+    // Cache frequently used classes and methods. A failed lookup must not leave
+    // its exception pending when JNI_OnLoad returns.
     jclass localStreamClass = (*env)->FindClass(env, "org/contentauth/c2pa/Stream");
     if (localStreamClass != NULL) {
         g_streamClass = (*env)->NewGlobalRef(env, localStreamClass);
         (*env)->DeleteLocalRef(env, localStreamClass);
-        
+
         g_streamReadMethod = (*env)->GetMethodID(env, g_streamClass, "read", "([BJ)J");
         g_streamSeekMethod = (*env)->GetMethodID(env, g_streamClass, "seek", "(JI)J");
         g_streamWriteMethod = (*env)->GetMethodID(env, g_streamClass, "write", "([BJ)J");
         g_streamFlushMethod = (*env)->GetMethodID(env, g_streamClass, "flush", "()J");
     }
-    
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+    }
+
     // SignerInfo class is no longer needed - parameters are passed directly
-    
+
     jclass localSignResultClass = (*env)->FindClass(env, "org/contentauth/c2pa/Builder$SignResult");
     if (localSignResultClass != NULL) {
         g_signResultClass = (*env)->NewGlobalRef(env, localSignResultClass);
         (*env)->DeleteLocalRef(env, localSignResultClass);
     }
-    
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+    }
+
     return JNI_VERSION_1_6;
 }
 
@@ -189,6 +196,19 @@ static int check_exception(JNIEnv *env) {
         return 1;
     }
     return 0;
+}
+
+// Throws className with message. FindClass can fail (returning NULL with its own
+// exception pending), and ThrowNew with a NULL class is undefined behavior, so
+// the class is checked first; on failure the FindClass exception is left pending
+// instead.
+static void throw_checked(JNIEnv *env, const char *className, const char *message) {
+    jclass cls = (*env)->FindClass(env, className);
+    if (cls == NULL) {
+        return;
+    }
+    (*env)->ThrowNew(env, cls, message);
+    (*env)->DeleteLocalRef(env, cls);
 }
 
 // Helper function to convert jstring to C string with null checking
@@ -355,8 +375,7 @@ static int finish_stashed_exception(JNIEnv *env, int failed) {
 // Helper for safe array allocation with error handling
 static jbyteArray safe_new_byte_array(JNIEnv *env, jsize size) {
     if (size < 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Array size cannot be negative");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Array size cannot be negative");
         return NULL;
     }
     
@@ -762,14 +781,24 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_C2PA_getError(JNIEnv *env, j
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PA_loadSettingsNative(JNIEnv *env, jclass clazz, jstring settings, jstring format) {
+    if (settings == NULL || format == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Settings and format cannot be null");
+        return -1;
+    }
+
     const char *csettings = jstring_to_cstring(env, settings);
     const char *cformat = jstring_to_cstring(env, format);
-    
+    if (csettings == NULL || cformat == NULL) {
+        release_cstring(env, settings, csettings);
+        release_cstring(env, format, cformat);
+        return -1;
+    }
+
     int result = c2pa_load_settings(csettings, cformat);
-    
+
     release_cstring(env, settings, csettings);
     release_cstring(env, format, cformat);
-    
+
     return result;
 }
 
@@ -777,8 +806,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PA_loadSettingsNative(JNIEnv 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Stream_createStreamNative(JNIEnv *env, jobject obj) {
     JavaStreamContext *ctx = (JavaStreamContext*)calloc(1, sizeof(JavaStreamContext));
     if (ctx == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/OutOfMemoryError"), 
-                         "Failed to allocate stream context");
+        throw_checked(env, "java/lang/OutOfMemoryError", "Failed to allocate stream context");
         return 0;
     }
     
@@ -786,8 +814,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Stream_createStreamNative(JNIE
     if (ctx->streamObject == NULL) {
         free(ctx);
         check_exception(env);
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/OutOfMemoryError"), 
-                         "Failed to create global reference");
+        throw_checked(env, "java/lang/OutOfMemoryError", "Failed to create global reference");
         return 0;
     }
     
@@ -796,8 +823,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Stream_createStreamNative(JNIE
         g_streamWriteMethod == NULL || g_streamFlushMethod == NULL) {
         (*env)->DeleteGlobalRef(env, ctx->streamObject);
         free(ctx);
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalStateException"), 
-                         "Stream method IDs not cached");
+        throw_checked(env, "java/lang/IllegalStateException", "Stream method IDs not cached");
         return 0;
     }
     
@@ -812,8 +838,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Stream_createStreamNative(JNIE
     if (stream == NULL) {
         (*env)->DeleteGlobalRef(env, ctx->streamObject);
         free(ctx);
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/RuntimeException"), 
-                         "Failed to create C2PA stream");
+        throw_checked(env, "java/lang/RuntimeException", "Failed to create C2PA stream");
         return 0;
     }
     
@@ -840,8 +865,7 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_Stream_releaseStreamNative(JNIE
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_fromStreamNative(JNIEnv *env, jclass clazz, jstring format, jlong streamPtr) {
     clear_stashed_exception(env);
     if (format == NULL || streamPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Format and stream cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format and stream cannot be null");
         return 0;
     }
     
@@ -878,8 +902,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_fromStreamNative(JNIEnv
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_fromManifestDataAndStreamNative(JNIEnv *env, jclass clazz, jstring format, jlong streamPtr, jbyteArray manifestData) {
     clear_stashed_exception(env);
     if (format == NULL || streamPtr == 0 || manifestData == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Format, stream, and manifest data cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format, stream, and manifest data cannot be null");
         return 0;
     }
     
@@ -898,8 +921,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_fromManifestDataAndStre
     
     if (dataSize <= 0) {
         release_cstring(env, format, cformat);
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Manifest data cannot be empty");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Manifest data cannot be empty");
         return 0;
     }
     
@@ -942,8 +964,7 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_Reader_free(JNIEnv *env, jobjec
 
 JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_toJsonNative(JNIEnv *env, jobject obj, jlong readerPtr) {
     if (readerPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalStateException"), 
-                         "Reader is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is not initialized");
         return NULL;
     }
     
@@ -961,8 +982,7 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_toJsonNative(JNIEnv *
 
 JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_toDetailedJsonNative(JNIEnv *env, jobject obj, jlong readerPtr) {
     if (readerPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalStateException"), 
-                         "Reader is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is not initialized");
         return NULL;
     }
     
@@ -980,8 +1000,7 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_toDetailedJsonNative(
 
 JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_crjsonNative(JNIEnv *env, jobject obj, jlong readerPtr) {
     if (readerPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalStateException"),
-                         "Reader is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is not initialized");
         return NULL;
     }
 
@@ -999,8 +1018,7 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_crjsonNative(JNIEnv *
 
 JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_remoteUrlNative(JNIEnv *env, jobject obj, jlong readerPtr) {
     if (readerPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalStateException"), 
-                         "Reader is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is not initialized");
         return NULL;
     }
     
@@ -1018,8 +1036,7 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_remoteUrlNative(JNIEn
 
 JNIEXPORT jboolean JNICALL Java_org_contentauth_c2pa_Reader_isEmbeddedNative(JNIEnv *env, jobject obj, jlong readerPtr) {
     if (readerPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalStateException"), 
-                         "Reader is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is not initialized");
         return JNI_FALSE;
     }
     
@@ -1030,8 +1047,7 @@ JNIEXPORT jboolean JNICALL Java_org_contentauth_c2pa_Reader_isEmbeddedNative(JNI
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_resourceToStreamNative(JNIEnv *env, jobject obj, jlong readerPtr, jstring uri, jlong streamPtr) {
     clear_stashed_exception(env);
     if (readerPtr == 0 || uri == NULL || streamPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Reader, URI, and stream cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Reader, URI, and stream cannot be null");
         return -1;
     }
     
@@ -1079,8 +1095,7 @@ JNIEXPORT jobjectArray JNICALL Java_org_contentauth_c2pa_Builder_supportedMimeTy
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_nativeFromArchive(JNIEnv *env, jclass clazz, jlong streamPtr) {
     clear_stashed_exception(env);
     if (streamPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Stream cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Stream cannot be null");
         return 0;
     }
     
@@ -1115,8 +1130,7 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_Builder_free(JNIEnv *env, jobje
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setIntentNative(JNIEnv *env, jobject obj, jlong builderPtr, jint intent, jint digitalSourceType) {
     if (builderPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalStateException"), 
-                         "Builder is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is not initialized");
         return -1;
     }
     
@@ -1126,8 +1140,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setIntentNative(JNIEnv 
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addActionNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring actionJson) {
     if (builderPtr == 0 || actionJson == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Builder and action JSON cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and action JSON cannot be null");
         return -1;
     }
     
@@ -1143,8 +1156,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addActionNative(JNIEnv 
 
 JNIEXPORT void JNICALL Java_org_contentauth_c2pa_Builder_setNoEmbedNative(JNIEnv *env, jobject obj, jlong builderPtr) {
     if (builderPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalStateException"), 
-                         "Builder is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is not initialized");
         return;
     }
     
@@ -1153,8 +1165,7 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_Builder_setNoEmbedNative(JNIEnv
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setRemoteUrlNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring remoteUrl) {
     if (builderPtr == 0 || remoteUrl == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Builder and remote URL cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and remote URL cannot be null");
         return -1;
     }
     
@@ -1170,8 +1181,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setRemoteUrlNative(JNIE
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setBasePathNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring basePath) {
     if (builderPtr == 0 || basePath == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and base path cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and base path cannot be null");
         return -1;
     }
 
@@ -1187,7 +1197,16 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setBasePathNative(JNIEn
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addResourceNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring uri, jlong streamPtr) {
     clear_stashed_exception(env);
+    if (builderPtr == 0 || uri == NULL || streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, URI, and stream cannot be null");
+        return -1;
+    }
+
     const char *curi = jstring_to_cstring(env, uri);
+    if (curi == NULL) {
+        return -1;
+    }
+
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
     int result = c2pa_builder_add_resource((struct C2paBuilder*)(uintptr_t)builderPtr, curi, stream);
     release_cstring(env, uri, curi);
@@ -1197,14 +1216,26 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addResourceNative(JNIEn
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromStreamNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring ingredientJson, jstring format, jlong streamPtr) {
     clear_stashed_exception(env);
+    if (builderPtr == 0 || ingredientJson == NULL || format == NULL || streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException",
+                      "Builder, ingredient JSON, format, and stream cannot be null");
+        return -1;
+    }
+
     const char *cingredientJson = jstring_to_cstring(env, ingredientJson);
     const char *cformat = jstring_to_cstring(env, format);
+    if (cingredientJson == NULL || cformat == NULL) {
+        release_cstring(env, ingredientJson, cingredientJson);
+        release_cstring(env, format, cformat);
+        return -1;
+    }
+
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
-    
+
     int result = c2pa_builder_add_ingredient_from_stream(
         (struct C2paBuilder*)(uintptr_t)builderPtr, cingredientJson, cformat, stream
     );
-    
+
     release_cstring(env, ingredientJson, cingredientJson);
     release_cstring(env, format, cformat);
 
@@ -1214,6 +1245,11 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromStream
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_toArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong streamPtr) {
     clear_stashed_exception(env);
+    if (builderPtr == 0 || streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and stream cannot be null");
+        return -1;
+    }
+
     struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
     struct C2paStream *stream = (struct C2paStream*)(uintptr_t)streamPtr;
     int result = c2pa_builder_to_archive(builder, stream);
@@ -1224,8 +1260,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_toArchiveNative(JNIEnv 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong streamPtr) {
     clear_stashed_exception(env);
     if (builderPtr == 0 || streamPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and stream cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and stream cannot be null");
         return -1;
     }
 
@@ -1239,8 +1274,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromArchiv
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_writeIngredientArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring ingredientId, jlong streamPtr) {
     clear_stashed_exception(env);
     if (builderPtr == 0 || ingredientId == NULL || streamPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder, ingredient id, and stream cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, ingredient id, and stream cannot be null");
         return -1;
     }
 
@@ -1311,8 +1345,7 @@ static jobject build_sign_result(JNIEnv *env, int64_t size, const unsigned char 
 JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong sourceStreamPtr, jlong destStreamPtr, jlong signerPtr) {
     clear_stashed_exception(env);
     if (builderPtr == 0 || format == NULL || sourceStreamPtr == 0 || destStreamPtr == 0 || signerPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Builder, format, streams, and signer cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, format, streams, and signer cannot be null");
         return NULL;
     }
     
@@ -1345,8 +1378,7 @@ JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signNative(JNIEnv *e
 JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signWithContextNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong sourceStreamPtr, jlong destStreamPtr) {
     clear_stashed_exception(env);
     if (builderPtr == 0 || format == NULL || sourceStreamPtr == 0 || destStreamPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder, format, and streams cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, format, and streams cannot be null");
         return NULL;
     }
 
@@ -1379,8 +1411,7 @@ JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signWithContextNativ
 // New Builder methods
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_dataHashedPlaceholderNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong reservedSize, jstring format) {
     if (builderPtr == 0 || format == NULL || reservedSize <= 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Builder, format cannot be null and reserved size must be positive");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, format cannot be null and reserved size must be positive");
         return NULL;
     }
     
@@ -1417,30 +1448,44 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_dataHashedPlaceho
 
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signDataHashedEmbeddableNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong signerPtr, jstring dataHash, jstring format, jlong assetPtr) {
     clear_stashed_exception(env);
+    if (builderPtr == 0 || signerPtr == 0 || dataHash == NULL || format == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException",
+                      "Builder, signer, data hash, and format cannot be null");
+        return NULL;
+    }
+
     struct C2paBuilder *builder = (struct C2paBuilder*)(uintptr_t)builderPtr;
     struct C2paSigner *signer = (struct C2paSigner*)(uintptr_t)signerPtr;
     const char *cdataHash = jstring_to_cstring(env, dataHash);
     const char *cformat = jstring_to_cstring(env, format);
+    if (cdataHash == NULL || cformat == NULL) {
+        release_cstring(env, dataHash, cdataHash);
+        release_cstring(env, format, cformat);
+        return NULL;
+    }
+
     struct C2paStream *asset = assetPtr != 0 ? (struct C2paStream*)(uintptr_t)assetPtr : NULL;
     const unsigned char *manifestBytes = NULL;
-    
+
     int64_t size = c2pa_builder_sign_data_hashed_embeddable(builder, signer, cdataHash, cformat, asset, &manifestBytes);
-    
+
     release_cstring(env, dataHash, cdataHash);
     release_cstring(env, format, cformat);
 
-    if (finish_stashed_exception(env, size < 0 || manifestBytes == NULL)) {
+    finish_stashed_exception(env, size < 0 || manifestBytes == NULL);
+    if (size < 0 || manifestBytes == NULL) {
         if (manifestBytes != NULL) {
             c2pa_free(manifestBytes);
         }
         return NULL;
     }
-    if (size < 0 || manifestBytes == NULL) {
+
+    jbyteArray result = safe_new_byte_array(env, (jsize)size);
+    if (result == NULL) {
+        c2pa_free(manifestBytes);
         return NULL;
     }
-
-    jbyteArray result = (*env)->NewByteArray(env, size);
-    (*env)->SetByteArrayRegion(env, result, 0, size, (const jbyte*)manifestBytes);
+    (*env)->SetByteArrayRegion(env, result, 0, (jsize)size, (const jbyte*)manifestBytes);
     c2pa_free(manifestBytes);
 
     return result;
@@ -1449,8 +1494,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signDataHashedEmb
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signEmbeddableNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
     clear_stashed_exception(env);
     if (builderPtr == 0 || format == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and format cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and format cannot be null");
         return NULL;
     }
 
@@ -1490,8 +1534,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signEmbeddableNat
 
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_placeholderNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
     if (builderPtr == 0 || format == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and format cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and format cannot be null");
         return NULL;
     }
 
@@ -1525,8 +1568,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_placeholderNative
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_needsPlaceholderNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
     if (builderPtr == 0 || format == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and format cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and format cannot be null");
         return -1;
     }
 
@@ -1542,15 +1584,13 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_needsPlaceholderNative(
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setDataHashExclusionsNative(JNIEnv *env, jobject obj, jlong builderPtr, jlongArray exclusions) {
     if (builderPtr == 0 || exclusions == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and exclusions cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and exclusions cannot be null");
         return -1;
     }
 
     jsize len = (*env)->GetArrayLength(env, exclusions);
     if (len % 2 != 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Exclusions must be a flat array of (start, length) pairs");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Exclusions must be a flat array of (start, length) pairs");
         return -1;
     }
 
@@ -1573,8 +1613,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setDataHashExclusionsNa
 
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_formatEmbeddableNative(JNIEnv *env, jclass clazz, jstring format, jbyteArray manifestData) {
     if (format == NULL || manifestData == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Format and manifest data cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format and manifest data cannot be null");
         return NULL;
     }
 
@@ -1617,8 +1656,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_formatEmbeddableN
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setFixedSizeMerkleNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong fixedSizeKb) {
     if (builderPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder cannot be null");
         return -1;
     }
     return c2pa_builder_set_fixed_size_merkle((struct C2paBuilder*)(uintptr_t)builderPtr, (uintptr_t)fixedSizeKb);
@@ -1626,8 +1664,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setFixedSizeMerkleNativ
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_hashMdatBytesNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong mdatId, jbyteArray data, jboolean largeSize) {
     if (builderPtr == 0 || data == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and data cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and data cannot be null");
         return -1;
     }
 
@@ -1653,8 +1690,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_hashMdatBytesNative(JNI
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_updateHashFromStreamNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong streamPtr) {
     clear_stashed_exception(env);
     if (builderPtr == 0 || format == NULL || streamPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder, format, and stream cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, format, and stream cannot be null");
         return -1;
     }
 
@@ -1676,8 +1712,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_updateHashFromStreamNat
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_hashTypeNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
     if (builderPtr == 0 || format == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and format cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and format cannot be null");
         return -1;
     }
 
@@ -1709,8 +1744,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromSettings(JNIE
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromInfo(JNIEnv *env, jclass clazz, jstring algorithm, jstring certificatePEM, jstring privateKeyPEM, jstring tsaURL) {
     if (algorithm == NULL || certificatePEM == NULL || privateKeyPEM == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Required parameters cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Required parameters cannot be null");
         return 0;
     }
     
@@ -1724,8 +1758,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromInfo(JNIEnv *
         release_cstring(env, certificatePEM, ccertificatePEM);
         release_cstring(env, privateKeyPEM, cprivateKeyPEM);
         release_cstring(env, tsaURL, ctsaURL);
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Required signer info fields cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Required signer info fields cannot be null");
         return 0;
     }
     
@@ -1862,8 +1895,7 @@ static void free_detached_contexts(JNIEnv *env, SignerContextNode *nodes) {
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromCallback(JNIEnv *env, jclass clazz, jstring algorithm, jstring certificateChain, jstring tsaURL, jobject callback) {
     if (algorithm == NULL || certificateChain == NULL || callback == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Required parameters cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Required parameters cannot be null");
         return 0;
     }
     
@@ -1881,8 +1913,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromCallback(JNIE
     else if (strcmp(calg, "ed25519") == 0) alg = Ed25519;
     else {
         release_cstring(env, algorithm, calg);
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Unknown signing algorithm");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Unknown signing algorithm");
         return 0;
     }
     
@@ -1901,8 +1932,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeFromCallback(JNIE
     if (ctx == NULL) {
         release_cstring(env, certificateChain, ccerts);
         release_cstring(env, tsaURL, ctsaURL);
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/OutOfMemoryError"), 
-                         "Failed to allocate signer context");
+        throw_checked(env, "java/lang/OutOfMemoryError", "Failed to allocate signer context");
         return 0;
     }
     
@@ -1978,18 +2008,14 @@ static int build_cstring_array(JNIEnv *env, jobjectArray jarray, const char ***o
     }
     const char **arr = (const char **)calloc((size_t)len + 1, sizeof(const char *));
     if (arr == NULL) {
-        (*env)->ThrowNew(env,
-                         (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
-                         "Failed to allocate string array");
+        throw_checked(env, "java/lang/OutOfMemoryError", "Failed to allocate string array");
         return -1;
     }
     for (jsize i = 0; i < len; i++) {
         jstring js = (jstring)(*env)->GetObjectArrayElement(env, jarray, i);
         if (js == NULL) {
             release_cstring_array(arr, len);
-            (*env)->ThrowNew(env,
-                             (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                             "Array element cannot be null");
+            throw_checked(env, "java/lang/IllegalArgumentException", "Array element cannot be null");
             return -1;
         }
         const char *cs = jstring_to_cstring(env, js);
@@ -1998,9 +2024,7 @@ static int build_cstring_array(JNIEnv *env, jobjectArray jarray, const char ***o
         (*env)->DeleteLocalRef(env, js);
         if (copy == NULL) {
             release_cstring_array(arr, len);
-            (*env)->ThrowNew(env,
-                             (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
-                             "Failed to copy array element");
+            throw_checked(env, "java/lang/OutOfMemoryError", "Failed to copy array element");
             return -1;
         }
         arr[i] = copy;
@@ -2012,17 +2036,13 @@ static int build_cstring_array(JNIEnv *env, jobjectArray jarray, const char ***o
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeCombineCawg(JNIEnv *env, jclass clazz, jlong c2paHandle, jlong identityHandle, jobjectArray referencedAssertions, jobjectArray roles) {
     if (c2paHandle == 0 || identityHandle == 0) {
-        (*env)->ThrowNew(env,
-                         (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Signer handles cannot be zero");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Signer handles cannot be zero");
         return 0;
     }
     if (c2paHandle == identityHandle) {
         // The FFI consumes each input; aliasing the same signer would untrack it
         // without freeing, leaking it irrecoverably.
-        (*env)->ThrowNew(env,
-                         (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "c2pa and identity signers must be distinct");
+        throw_checked(env, "java/lang/IllegalArgumentException", "c2pa and identity signers must be distinct");
         return 0;
     }
 
@@ -2065,6 +2085,10 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeCombineCawg(JNIEn
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_reserveSizeNative(JNIEnv *env, jobject obj, jlong signerPtr) {
+    if (signerPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Signer is not initialized");
+        return -1;
+    }
     return c2pa_signer_reserve_size((struct C2paSigner*)(uintptr_t)signerPtr);
 }
 
@@ -2183,8 +2207,7 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_C2PAContext_free(JNIEnv *env, j
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContext_cancelNative(JNIEnv *env, jobject obj, jlong contextPtr) {
     if (contextPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Context cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Context cannot be null");
         return -1;
     }
     return c2pa_context_cancel((struct C2paContext*)(uintptr_t)contextPtr);
@@ -2210,8 +2233,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_nativeNew(J
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setSettingsNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong settingsPtr) {
     if (builderPtr == 0 || settingsPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and settings cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and settings cannot be null");
         return -1;
     }
     return c2pa_context_builder_set_settings(
@@ -2222,8 +2244,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setSettingsN
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setSignerNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong signerPtr) {
     if (builderPtr == 0 || signerPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and signer cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and signer cannot be null");
         return -1;
     }
     // The FFI consumes the signer; the Kotlin wrapper zeros its pointer on success.
@@ -2235,15 +2256,13 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setSignerNat
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgressCallbackNative(JNIEnv *env, jobject obj, jlong builderPtr, jobject bridge) {
     if (builderPtr == 0 || bridge == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and progress callback cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and progress callback cannot be null");
         return 0;
     }
 
     JavaContextCallback *jctx = (JavaContextCallback*)calloc(1, sizeof(JavaContextCallback));
     if (jctx == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
-                         "Failed to allocate progress callback context");
+        throw_checked(env, "java/lang/OutOfMemoryError", "Failed to allocate progress callback context");
         return 0;
     }
 
@@ -2269,8 +2288,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgress
     if (!register_context_callback(jctx)) {
         (*env)->DeleteGlobalRef(env, jctx->callback);
         free(jctx);
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
-                         "Failed to register progress callback");
+        throw_checked(env, "java/lang/OutOfMemoryError", "Failed to register progress callback");
         return 0;
     }
 
@@ -2293,15 +2311,13 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgress
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setHttpResolverNative(JNIEnv *env, jobject obj, jlong builderPtr, jobject bridge) {
     if (builderPtr == 0 || bridge == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and HTTP resolver cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and HTTP resolver cannot be null");
         return 0;
     }
 
     JavaContextCallback *jctx = (JavaContextCallback*)calloc(1, sizeof(JavaContextCallback));
     if (jctx == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
-                         "Failed to allocate HTTP resolver context");
+        throw_checked(env, "java/lang/OutOfMemoryError", "Failed to allocate HTTP resolver context");
         return 0;
     }
 
@@ -2328,8 +2344,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setHttpReso
     if (!register_context_callback(jctx)) {
         (*env)->DeleteGlobalRef(env, jctx->callback);
         free(jctx);
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/OutOfMemoryError"),
-                         "Failed to register HTTP resolver");
+        throw_checked(env, "java/lang/OutOfMemoryError", "Failed to register HTTP resolver");
         return 0;
     }
 
@@ -2374,8 +2389,7 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_free(JNIEnv 
 // Builder context-based methods
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_nativeFromContext(JNIEnv *env, jclass clazz, jlong contextPtr) {
     if (contextPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Context cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Context cannot be null");
         return 0;
     }
 
@@ -2391,8 +2405,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_nativeFromContext(JNIE
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withDefinitionNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring manifestJson) {
     if (builderPtr == 0 || manifestJson == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and manifest JSON cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and manifest JSON cannot be null");
         return 0;
     }
 
@@ -2416,8 +2429,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withDefinitionNative(J
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong streamPtr) {
     clear_stashed_exception(env);
     if (builderPtr == 0 || streamPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Builder and stream cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and stream cannot be null");
         return 0;
     }
 
@@ -2438,8 +2450,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withArchiveNative(JNIE
 // Reader context-based methods
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_nativeFromContext(JNIEnv *env, jclass clazz, jlong contextPtr) {
     if (contextPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Context cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Context cannot be null");
         return 0;
     }
 
@@ -2456,8 +2467,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_nativeFromContext(JNIEn
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withStreamNative(JNIEnv *env, jobject obj, jlong readerPtr, jstring format, jlong streamPtr) {
     clear_stashed_exception(env);
     if (readerPtr == 0 || format == NULL || streamPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Reader, format, and stream cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Reader, format, and stream cannot be null");
         return 0;
     }
 
@@ -2484,8 +2494,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withStreamNative(JNIEnv
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withFragmentNative(JNIEnv *env, jobject obj, jlong readerPtr, jstring format, jlong streamPtr, jlong fragmentPtr) {
     clear_stashed_exception(env);
     if (readerPtr == 0 || format == NULL || streamPtr == 0 || fragmentPtr == 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"),
-                         "Reader, format, stream, and fragment cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Reader, format, stream, and fragment cannot be null");
         return 0;
     }
 
@@ -2513,15 +2522,13 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withFragmentNative(JNIE
 // Ed25519 signing
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_C2PA_ed25519SignNative(JNIEnv *env, jclass clazz, jbyteArray data, jstring privateKey) {
     if (data == NULL || privateKey == NULL) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Data and private key cannot be null");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Data and private key cannot be null");
         return NULL;
     }
     
     jsize dataSize = (*env)->GetArrayLength(env, data);
     if (check_exception(env) || dataSize <= 0) {
-        (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), 
-                         "Data cannot be empty");
+        throw_checked(env, "java/lang/IllegalArgumentException", "Data cannot be empty");
         return NULL;
     }
     

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -975,7 +975,7 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_Reader_free(JNIEnv *env, jobjec
 
 JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_toJsonNative(JNIEnv *env, jobject obj, jlong readerPtr) {
     if (readerPtr == 0) {
-        throw_checked(env, "java/lang/IllegalStateException", "Reader is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is closed");
         return NULL;
     }
     
@@ -993,7 +993,7 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_toJsonNative(JNIEnv *
 
 JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_toDetailedJsonNative(JNIEnv *env, jobject obj, jlong readerPtr) {
     if (readerPtr == 0) {
-        throw_checked(env, "java/lang/IllegalStateException", "Reader is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is closed");
         return NULL;
     }
     
@@ -1011,7 +1011,7 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_toDetailedJsonNative(
 
 JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_crjsonNative(JNIEnv *env, jobject obj, jlong readerPtr) {
     if (readerPtr == 0) {
-        throw_checked(env, "java/lang/IllegalStateException", "Reader is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is closed");
         return NULL;
     }
 
@@ -1029,7 +1029,7 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_crjsonNative(JNIEnv *
 
 JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_remoteUrlNative(JNIEnv *env, jobject obj, jlong readerPtr) {
     if (readerPtr == 0) {
-        throw_checked(env, "java/lang/IllegalStateException", "Reader is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is closed");
         return NULL;
     }
     
@@ -1047,7 +1047,7 @@ JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_Reader_remoteUrlNative(JNIEn
 
 JNIEXPORT jboolean JNICALL Java_org_contentauth_c2pa_Reader_isEmbeddedNative(JNIEnv *env, jobject obj, jlong readerPtr) {
     if (readerPtr == 0) {
-        throw_checked(env, "java/lang/IllegalStateException", "Reader is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is closed");
         return JNI_FALSE;
     }
     
@@ -1057,8 +1057,12 @@ JNIEXPORT jboolean JNICALL Java_org_contentauth_c2pa_Reader_isEmbeddedNative(JNI
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_resourceToStreamNative(JNIEnv *env, jobject obj, jlong readerPtr, jstring uri, jlong streamPtr) {
     clear_stashed_exception(env);
-    if (readerPtr == 0 || uri == NULL || streamPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Reader, URI, and stream cannot be null");
+    if (readerPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is closed");
+        return -1;
+    }
+    if (uri == NULL || streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "URI and stream cannot be null");
         return -1;
     }
     
@@ -1141,7 +1145,7 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_Builder_free(JNIEnv *env, jobje
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setIntentNative(JNIEnv *env, jobject obj, jlong builderPtr, jint intent, jint digitalSourceType) {
     if (builderPtr == 0) {
-        throw_checked(env, "java/lang/IllegalStateException", "Builder is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
         return -1;
     }
     
@@ -1150,8 +1154,12 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setIntentNative(JNIEnv 
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addActionNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring actionJson) {
-    if (builderPtr == 0 || actionJson == NULL) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and action JSON cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (actionJson == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Action JSON cannot be null");
         return -1;
     }
     
@@ -1167,7 +1175,7 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addActionNative(JNIEnv 
 
 JNIEXPORT void JNICALL Java_org_contentauth_c2pa_Builder_setNoEmbedNative(JNIEnv *env, jobject obj, jlong builderPtr) {
     if (builderPtr == 0) {
-        throw_checked(env, "java/lang/IllegalStateException", "Builder is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
         return;
     }
     
@@ -1175,8 +1183,12 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_Builder_setNoEmbedNative(JNIEnv
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setRemoteUrlNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring remoteUrl) {
-    if (builderPtr == 0 || remoteUrl == NULL) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and remote URL cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (remoteUrl == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Remote URL cannot be null");
         return -1;
     }
     
@@ -1191,8 +1203,12 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setRemoteUrlNative(JNIE
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setBasePathNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring basePath) {
-    if (builderPtr == 0 || basePath == NULL) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and base path cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (basePath == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Base path cannot be null");
         return -1;
     }
 
@@ -1208,8 +1224,12 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setBasePathNative(JNIEn
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addResourceNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring uri, jlong streamPtr) {
     clear_stashed_exception(env);
-    if (builderPtr == 0 || uri == NULL || streamPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, URI, and stream cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (uri == NULL || streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "URI and stream cannot be null");
         return -1;
     }
 
@@ -1227,9 +1247,12 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addResourceNative(JNIEn
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromStreamNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring ingredientJson, jstring format, jlong streamPtr) {
     clear_stashed_exception(env);
-    if (builderPtr == 0 || ingredientJson == NULL || format == NULL || streamPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException",
-                      "Builder, ingredient JSON, format, and stream cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (ingredientJson == NULL || format == NULL || streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Ingredient JSON, format, and stream cannot be null");
         return -1;
     }
 
@@ -1256,8 +1279,12 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromStream
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_toArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong streamPtr) {
     clear_stashed_exception(env);
-    if (builderPtr == 0 || streamPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and stream cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Stream cannot be null");
         return -1;
     }
 
@@ -1270,8 +1297,12 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_toArchiveNative(JNIEnv 
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong streamPtr) {
     clear_stashed_exception(env);
-    if (builderPtr == 0 || streamPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and stream cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Stream cannot be null");
         return -1;
     }
 
@@ -1284,8 +1315,12 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_addIngredientFromArchiv
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_writeIngredientArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring ingredientId, jlong streamPtr) {
     clear_stashed_exception(env);
-    if (builderPtr == 0 || ingredientId == NULL || streamPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, ingredient id, and stream cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (ingredientId == NULL || streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Ingredient id and stream cannot be null");
         return -1;
     }
 
@@ -1355,8 +1390,12 @@ static jobject build_sign_result(JNIEnv *env, int64_t size, const unsigned char 
 
 JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong sourceStreamPtr, jlong destStreamPtr, jlong signerPtr) {
     clear_stashed_exception(env);
-    if (builderPtr == 0 || format == NULL || sourceStreamPtr == 0 || destStreamPtr == 0 || signerPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, format, streams, and signer cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return NULL;
+    }
+    if (format == NULL || sourceStreamPtr == 0 || destStreamPtr == 0 || signerPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format, streams, and signer cannot be null");
         return NULL;
     }
     
@@ -1388,8 +1427,12 @@ JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signNative(JNIEnv *e
 
 JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signWithContextNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong sourceStreamPtr, jlong destStreamPtr) {
     clear_stashed_exception(env);
-    if (builderPtr == 0 || format == NULL || sourceStreamPtr == 0 || destStreamPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, format, and streams cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return NULL;
+    }
+    if (format == NULL || sourceStreamPtr == 0 || destStreamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format and streams cannot be null");
         return NULL;
     }
 
@@ -1421,8 +1464,12 @@ JNIEXPORT jobject JNICALL Java_org_contentauth_c2pa_Builder_signWithContextNativ
 
 // New Builder methods
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_dataHashedPlaceholderNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong reservedSize, jstring format) {
-    if (builderPtr == 0 || format == NULL || reservedSize <= 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, format cannot be null and reserved size must be positive");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return NULL;
+    }
+    if (format == NULL || reservedSize <= 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format cannot be null and reserved size must be positive");
         return NULL;
     }
     
@@ -1464,9 +1511,12 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_dataHashedPlaceho
 
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signDataHashedEmbeddableNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong signerPtr, jstring dataHash, jstring format, jlong assetPtr) {
     clear_stashed_exception(env);
-    if (builderPtr == 0 || signerPtr == 0 || dataHash == NULL || format == NULL) {
-        throw_checked(env, "java/lang/IllegalArgumentException",
-                      "Builder, signer, data hash, and format cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return NULL;
+    }
+    if (signerPtr == 0 || dataHash == NULL || format == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Signer, data hash, and format cannot be null");
         return NULL;
     }
 
@@ -1509,8 +1559,12 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signDataHashedEmb
 
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signEmbeddableNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
     clear_stashed_exception(env);
-    if (builderPtr == 0 || format == NULL) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and format cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return NULL;
+    }
+    if (format == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format cannot be null");
         return NULL;
     }
 
@@ -1549,8 +1603,12 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_signEmbeddableNat
 }
 
 JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_placeholderNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
-    if (builderPtr == 0 || format == NULL) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and format cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return NULL;
+    }
+    if (format == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format cannot be null");
         return NULL;
     }
 
@@ -1583,8 +1641,12 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_placeholderNative
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_needsPlaceholderNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
-    if (builderPtr == 0 || format == NULL) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and format cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (format == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format cannot be null");
         return -1;
     }
 
@@ -1599,8 +1661,12 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_needsPlaceholderNative(
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setDataHashExclusionsNative(JNIEnv *env, jobject obj, jlong builderPtr, jlongArray exclusions) {
-    if (builderPtr == 0 || exclusions == NULL) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and exclusions cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (exclusions == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Exclusions cannot be null");
         return -1;
     }
 
@@ -1672,7 +1738,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_contentauth_c2pa_Builder_formatEmbeddableN
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setFixedSizeMerkleNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong fixedSizeKb) {
     if (builderPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder cannot be null");
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
         return -1;
     }
     if (fixedSizeKb < 0 || (uint64_t)fixedSizeKb != (uint64_t)(uintptr_t)fixedSizeKb) {
@@ -1683,8 +1749,12 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_setFixedSizeMerkleNativ
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_hashMdatBytesNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong mdatId, jbyteArray data, jboolean largeSize) {
-    if (builderPtr == 0 || data == NULL) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and data cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (data == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Data cannot be null");
         return -1;
     }
 
@@ -1714,8 +1784,12 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_hashMdatBytesNative(JNI
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_updateHashFromStreamNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format, jlong streamPtr) {
     clear_stashed_exception(env);
-    if (builderPtr == 0 || format == NULL || streamPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder, format, and stream cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (format == NULL || streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format and stream cannot be null");
         return -1;
     }
 
@@ -1736,8 +1810,12 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_updateHashFromStreamNat
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_Builder_hashTypeNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring format) {
-    if (builderPtr == 0 || format == NULL) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and format cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return -1;
+    }
+    if (format == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format cannot be null");
         return -1;
     }
 
@@ -2111,7 +2189,7 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_nativeCombineCawg(JNIEn
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Signer_reserveSizeNative(JNIEnv *env, jobject obj, jlong signerPtr) {
     if (signerPtr == 0) {
-        throw_checked(env, "java/lang/IllegalStateException", "Signer is not initialized");
+        throw_checked(env, "java/lang/IllegalStateException", "Signer is closed");
         return -1;
     }
     return c2pa_signer_reserve_size((struct C2paSigner*)(uintptr_t)signerPtr);
@@ -2232,7 +2310,7 @@ JNIEXPORT void JNICALL Java_org_contentauth_c2pa_C2PAContext_free(JNIEnv *env, j
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContext_cancelNative(JNIEnv *env, jobject obj, jlong contextPtr) {
     if (contextPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Context cannot be null");
+        throw_checked(env, "java/lang/IllegalStateException", "C2PAContext is closed");
         return -1;
     }
     return c2pa_context_cancel((struct C2paContext*)(uintptr_t)contextPtr);
@@ -2257,7 +2335,11 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_nativeNew(J
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setSettingsNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong settingsPtr) {
-    if (builderPtr == 0 || settingsPtr == 0) {
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "C2PAContextBuilder is closed");
+        return -1;
+    }
+    if (settingsPtr == 0) {
         throw_checked(env, "java/lang/IllegalArgumentException", "Builder and settings cannot be null");
         return -1;
     }
@@ -2268,7 +2350,11 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setSettingsN
 }
 
 JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setSignerNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong signerPtr) {
-    if (builderPtr == 0 || signerPtr == 0) {
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "C2PAContextBuilder is closed");
+        return -1;
+    }
+    if (signerPtr == 0) {
         throw_checked(env, "java/lang/IllegalArgumentException", "Builder and signer cannot be null");
         return -1;
     }
@@ -2280,7 +2366,11 @@ JNIEXPORT jint JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setSignerNat
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgressCallbackNative(JNIEnv *env, jobject obj, jlong builderPtr, jobject bridge) {
-    if (builderPtr == 0 || bridge == NULL) {
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "C2PAContextBuilder is closed");
+        return 0;
+    }
+    if (bridge == NULL) {
         throw_checked(env, "java/lang/IllegalArgumentException", "Builder and progress callback cannot be null");
         return 0;
     }
@@ -2335,7 +2425,11 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setProgress
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_C2PAContextBuilder_setHttpResolverNative(JNIEnv *env, jobject obj, jlong builderPtr, jobject bridge) {
-    if (builderPtr == 0 || bridge == NULL) {
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "C2PAContextBuilder is closed");
+        return 0;
+    }
+    if (bridge == NULL) {
         throw_checked(env, "java/lang/IllegalArgumentException", "Builder and HTTP resolver cannot be null");
         return 0;
     }
@@ -2429,8 +2523,12 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_nativeFromContext(JNIE
 }
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withDefinitionNative(JNIEnv *env, jobject obj, jlong builderPtr, jstring manifestJson) {
-    if (builderPtr == 0 || manifestJson == NULL) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and manifest JSON cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return 0;
+    }
+    if (manifestJson == NULL) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Manifest JSON cannot be null");
         return 0;
     }
 
@@ -2453,8 +2551,12 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withDefinitionNative(J
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Builder_withArchiveNative(JNIEnv *env, jobject obj, jlong builderPtr, jlong streamPtr) {
     clear_stashed_exception(env);
-    if (builderPtr == 0 || streamPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Builder and stream cannot be null");
+    if (builderPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Builder is closed");
+        return 0;
+    }
+    if (streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Stream cannot be null");
         return 0;
     }
 
@@ -2491,8 +2593,12 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_nativeFromContext(JNIEn
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withStreamNative(JNIEnv *env, jobject obj, jlong readerPtr, jstring format, jlong streamPtr) {
     clear_stashed_exception(env);
-    if (readerPtr == 0 || format == NULL || streamPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Reader, format, and stream cannot be null");
+    if (readerPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is closed");
+        return 0;
+    }
+    if (format == NULL || streamPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format and stream cannot be null");
         return 0;
     }
 
@@ -2518,8 +2624,12 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withStreamNative(JNIEnv
 
 JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Reader_withFragmentNative(JNIEnv *env, jobject obj, jlong readerPtr, jstring format, jlong streamPtr, jlong fragmentPtr) {
     clear_stashed_exception(env);
-    if (readerPtr == 0 || format == NULL || streamPtr == 0 || fragmentPtr == 0) {
-        throw_checked(env, "java/lang/IllegalArgumentException", "Reader, format, stream, and fragment cannot be null");
+    if (readerPtr == 0) {
+        throw_checked(env, "java/lang/IllegalStateException", "Reader is closed");
+        return 0;
+    }
+    if (format == NULL || streamPtr == 0 || fragmentPtr == 0) {
+        throw_checked(env, "java/lang/IllegalArgumentException", "Format, stream, and fragment cannot be null");
         return 0;
     }
 

--- a/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Builder.kt
@@ -93,7 +93,8 @@ import org.contentauth.c2pa.manifest.ManifestValidator
  * ## Resource Management
  *
  * Builder implements [Closeable] and must be closed when done to free native resources. Use `use {
- * }` or explicitly call `close()`.
+ * }` or explicitly call `close()`. Calling any method after `close()` (or after a failed
+ * [withDefinition] / [withArchive], which consume the builder) throws [IllegalStateException].
  *
  * @property ptr Internal pointer to the native C2PA builder instance
  * @see Reader

--- a/library/src/main/kotlin/org/contentauth/c2pa/Reader.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Reader.kt
@@ -59,7 +59,8 @@ import java.io.Closeable
  * ## Resource Management
  *
  * Reader implements [Closeable] and must be closed when done to free native resources. Use `use {
- * }` or explicitly call `close()`.
+ * }` or explicitly call `close()`. Calling any method after `close()` (or after a failed
+ * [withStream] / [withFragment], which consume the reader) throws [IllegalStateException].
  *
  * @property ptr Internal pointer to the native C2PA reader instance
  * @see Builder

--- a/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Signer.kt
@@ -19,7 +19,11 @@ interface SignCallback {
     fun sign(data: ByteArray): ByteArray
 }
 
-/** C2PA Signer for signing manifests */
+/**
+ * C2PA Signer for signing manifests.
+ *
+ * Signer implements [Closeable]; calling a method after `close()` throws [IllegalStateException].
+ */
 class Signer internal constructor(internal var ptr: Long) : Closeable {
 
     companion object {

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -202,6 +202,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBmffMerkleHashing())
     results.add(builderTests.testBuilderEmbeddableErrorPaths())
     results.add(builderTests.testContextProgressCallback())
+    results.add(builderTests.testClosedHandleValidation())
     results.add(builderTests.testContextCloseDuringSign())
     results.add(builderTests.testContextHttpResolver())
     results.add(builderTests.testContextHttpResolverOkHttp())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -938,6 +938,53 @@ abstract class BuilderTests : TestBase() {
         }
     }
 
+    suspend fun testClosedHandleValidation(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Closed Handle Validation") {
+            // Calls on closed handles must be rejected with a typed exception at the
+            // JNI boundary rather than passing a null pointer into the FFI.
+            val unexpected = mutableListOf<String>()
+            fun expect(label: String, expected: Class<out Exception>, block: () -> Unit) {
+                try {
+                    block()
+                    unexpected.add("$label did not throw")
+                } catch (e: Exception) {
+                    if (!expected.isInstance(e)) {
+                        unexpected.add("$label threw ${e.javaClass.simpleName}")
+                    }
+                }
+            }
+
+            val builder = Builder.fromJson(TEST_MANIFEST_JSON)
+            builder.close()
+            expect("toArchive on closed builder", IllegalArgumentException::class.java) {
+                ByteArrayStream().use { builder.toArchive(it) }
+            }
+            expect("addResource on closed builder", IllegalArgumentException::class.java) {
+                ByteArrayStream(byteArrayOf(1)).use { builder.addResource("thumbnail", it) }
+            }
+
+            val certPem = loadResourceAsString("es256_certs")
+            val keyPem = loadResourceAsString("es256_private")
+            val signer = Signer.fromInfo(SignerInfo(SigningAlgorithm.ES256, certPem, keyPem))
+            signer.close()
+            expect("reserveSize on closed signer", IllegalStateException::class.java) {
+                signer.reserveSize()
+            }
+
+            val success = unexpected.isEmpty()
+            TestResult(
+                "Closed Handle Validation",
+                success,
+                if (success) {
+                    "Closed handles rejected with typed exceptions"
+                } else {
+                    "Unexpected: $unexpected"
+                },
+                "Checked toArchive, addResource, reserveSize on closed handles",
+            )
+        }
+    }
+
     suspend fun testContextCloseDuringSign(): TestResult = withContext(Dispatchers.IO) {
         runTest("Context Close During Sign") {
             try {

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -954,13 +954,29 @@ abstract class BuilderTests : TestBase() {
                 }
             }
 
+            // Use after close is always IllegalStateException, regardless of how many
+            // other arguments the method takes; null arguments on a live handle stay
+            // IllegalArgumentException.
             val builder = Builder.fromJson(TEST_MANIFEST_JSON)
             builder.close()
-            expect("toArchive on closed builder", IllegalArgumentException::class.java) {
+            expect("toArchive on closed builder", IllegalStateException::class.java) {
                 ByteArrayStream().use { builder.toArchive(it) }
             }
-            expect("addResource on closed builder", IllegalArgumentException::class.java) {
+            expect("addResource on closed builder", IllegalStateException::class.java) {
                 ByteArrayStream(byteArrayOf(1)).use { builder.addResource("thumbnail", it) }
+            }
+            expect("setNoEmbed on closed builder", IllegalStateException::class.java) {
+                builder.setNoEmbed()
+            }
+
+            val testImageData = loadResourceAsBytes("adobe_20220124_ci")
+            val reader = ByteArrayStream(testImageData).use { Reader.fromStream("image/jpeg", it) }
+            reader.close()
+            expect("json on closed reader", IllegalStateException::class.java) {
+                reader.json()
+            }
+            expect("resource on closed reader", IllegalStateException::class.java) {
+                ByteArrayStream().use { reader.resource("thumbnail", it) }
             }
 
             val certPem = loadResourceAsString("es256_certs")
@@ -980,7 +996,7 @@ abstract class BuilderTests : TestBase() {
                 } else {
                     "Unexpected: $unexpected"
                 },
-                "Checked toArchive, addResource, reserveSize on closed handles",
+                "Checked builder, reader, and signer methods on closed handles",
             )
         }
     }


### PR DESCRIPTION
## Changes in this pull request
Aligns every JNI error path with the library's Kotlin-throws convention (FFI failures return sentinels and the wrappers raise C2PAError, as their contracts document), adds the missing argument validation and a checked-throw helper across the bridge, and fixes 64-bit truncation bugs affecting the 32-bit ABIs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment