### PR TITLE
Fix: Bridge JNI strings as standard UTF-8

### DIFF
--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -178,6 +178,12 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestEmbeddedNulRejected() = runBlocking {
+        val result = testEmbeddedNulRejected()
+        assertTrue(result.success, "Embedded NUL Rejected test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestClosedHandleValidation() = runBlocking {
         val result = testClosedHandleValidation()
         assertTrue(result.success, "Closed Handle Validation test failed: ${result.message}")

--- a/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
+++ b/library/src/androidTest/kotlin/org/contentauth/c2pa/AndroidBuilderTests.kt
@@ -172,6 +172,12 @@ class AndroidBuilderTests : BuilderTests() {
     }
 
     @Test
+    fun runTestUnicodeManifestRoundTrip() = runBlocking {
+        val result = testUnicodeManifestRoundTrip()
+        assertTrue(result.success, "Unicode Manifest Round Trip test failed: ${result.message}")
+    }
+
+    @Test
     fun runTestClosedHandleValidation() = runBlocking {
         val result = testClosedHandleValidation()
         assertTrue(result.success, "Closed Handle Validation test failed: ${result.message}")

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -282,7 +282,9 @@ static const char* jstring_to_cstring(JNIEnv *env, jstring jstr) {
     return out;
 }
 
-// Frees a string produced by jstring_to_cstring.
+// Frees a string produced by jstring_to_cstring. The env and jstr parameters
+// are unused now that the buffer is malloc'd rather than pinned; they are kept
+// so the many call sites keep their release-what-you-converted shape.
 static void release_cstring(JNIEnv *env, jstring jstr, const char* cstr) {
     (void)env;
     (void)jstr;
@@ -2230,16 +2232,16 @@ static int build_cstring_array(JNIEnv *env, jobjectArray jarray, const char ***o
             throw_checked(env, "java/lang/IllegalArgumentException", "Array element cannot be null");
             return -1;
         }
+        // jstring_to_cstring returns a malloc'd buffer, so the array takes
+        // ownership directly; release_cstring_array frees each element.
         const char *cs = jstring_to_cstring(env, js);
-        char *copy = cs != NULL ? strdup(cs) : NULL;
-        release_cstring(env, js, cs);
         (*env)->DeleteLocalRef(env, js);
-        if (copy == NULL) {
+        if (cs == NULL) {
+            // Conversion failed with its exception already pending.
             release_cstring_array(arr, len);
-            throw_checked(env, "java/lang/OutOfMemoryError", "Failed to copy array element");
             return -1;
         }
-        arr[i] = copy;
+        arr[i] = cs;
     }
     *out_array = arr;
     *out_len = len;

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -219,7 +219,8 @@ static void throw_checked(JNIEnv *env, const char *className, const char *messag
 // U+FFFD in both directions.
 
 // Converts a jstring to a NUL-terminated, malloc-allocated standard UTF-8 string.
-// Release with release_cstring.
+// Release with release_cstring. Returns NULL with an exception pending if the
+// string contains U+0000 or the conversion cannot be allocated.
 static const char* jstring_to_cstring(JNIEnv *env, jstring jstr) {
     if (jstr == NULL) return NULL;
 
@@ -242,6 +243,15 @@ static const char* jstring_to_cstring(JNIEnv *env, jstring jstr) {
     size_t o = 0;
     for (jsize i = 0; i < ulen; i++) {
         uint32_t cp = chars[i];
+        if (cp == 0) {
+            // The result is a NUL-terminated C string, so an embedded U+0000
+            // would silently truncate it. Reject it rather than hand the core
+            // a shorter string than the caller passed.
+            free(out);
+            (*env)->ReleaseStringChars(env, jstr, chars);
+            throw_checked(env, "java/lang/IllegalArgumentException", "String must not contain U+0000");
+            return NULL;
+        }
         if (cp >= 0xD800 && cp <= 0xDBFF && i + 1 < ulen &&
             chars[i + 1] >= 0xDC00 && chars[i + 1] <= 0xDFFF) {
             cp = 0x10000 + ((cp - 0xD800) << 10) + (chars[i + 1] - 0xDC00);

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -211,27 +211,126 @@ static void throw_checked(JNIEnv *env, const char *className, const char *messag
     (*env)->DeleteLocalRef(env, cls);
 }
 
-// Helper function to convert jstring to C string with null checking
+// String bridging transcodes through UTF-16 (GetStringChars/NewString) with the
+// UTF-8 conversion done here, because GetStringUTFChars/NewStringUTF operate in
+// JNI *modified* UTF-8: supplementary-plane characters (e.g. emoji in a manifest
+// title) become CESU-8 surrogate pairs the Rust FFI rejects, and NewStringUTF on
+// a genuine 4-byte UTF-8 sequence is undefined behavior. Malformed input maps to
+// U+FFFD in both directions.
+
+// Converts a jstring to a NUL-terminated, malloc-allocated standard UTF-8 string.
+// Release with release_cstring.
 static const char* jstring_to_cstring(JNIEnv *env, jstring jstr) {
     if (jstr == NULL) return NULL;
-    const char* cstr = (*env)->GetStringUTFChars(env, jstr, NULL);
-    if (cstr == NULL) {
+
+    jsize ulen = (*env)->GetStringLength(env, jstr);
+    const jchar *chars = (*env)->GetStringChars(env, jstr, NULL);
+    if (chars == NULL) {
         check_exception(env);
+        return NULL;
     }
-    return cstr;
+
+    // Worst case is 3 bytes per UTF-16 code unit (a surrogate pair emits 4 bytes
+    // for its 2 units, and U+FFFD replacements emit 3).
+    char *out = (char*)malloc((size_t)ulen * 3 + 1);
+    if (out == NULL) {
+        (*env)->ReleaseStringChars(env, jstr, chars);
+        throw_checked(env, "java/lang/OutOfMemoryError", "Failed to allocate UTF-8 buffer");
+        return NULL;
+    }
+
+    size_t o = 0;
+    for (jsize i = 0; i < ulen; i++) {
+        uint32_t cp = chars[i];
+        if (cp >= 0xD800 && cp <= 0xDBFF && i + 1 < ulen &&
+            chars[i + 1] >= 0xDC00 && chars[i + 1] <= 0xDFFF) {
+            cp = 0x10000 + ((cp - 0xD800) << 10) + (chars[i + 1] - 0xDC00);
+            i++;
+        } else if (cp >= 0xD800 && cp <= 0xDFFF) {
+            cp = 0xFFFD;  // Unpaired surrogate
+        }
+
+        if (cp < 0x80) {
+            out[o++] = (char)cp;
+        } else if (cp < 0x800) {
+            out[o++] = (char)(0xC0 | (cp >> 6));
+            out[o++] = (char)(0x80 | (cp & 0x3F));
+        } else if (cp < 0x10000) {
+            out[o++] = (char)(0xE0 | (cp >> 12));
+            out[o++] = (char)(0x80 | ((cp >> 6) & 0x3F));
+            out[o++] = (char)(0x80 | (cp & 0x3F));
+        } else {
+            out[o++] = (char)(0xF0 | (cp >> 18));
+            out[o++] = (char)(0x80 | ((cp >> 12) & 0x3F));
+            out[o++] = (char)(0x80 | ((cp >> 6) & 0x3F));
+            out[o++] = (char)(0x80 | (cp & 0x3F));
+        }
+    }
+    out[o] = '\0';
+
+    (*env)->ReleaseStringChars(env, jstr, chars);
+    return out;
 }
 
-// Helper function to release C string from jstring
+// Frees a string produced by jstring_to_cstring.
 static void release_cstring(JNIEnv *env, jstring jstr, const char* cstr) {
-    if (jstr != NULL && cstr != NULL) {
-        (*env)->ReleaseStringUTFChars(env, jstr, cstr);
-    }
+    (void)env;
+    (void)jstr;
+    free((void*)cstr);
 }
 
-// Helper function to convert C string to jstring with null checking
+// Converts a NUL-terminated standard UTF-8 string to a jstring.
 static jstring cstring_to_jstring(JNIEnv *env, const char* cstr) {
     if (cstr == NULL) return NULL;
-    jstring jstr = (*env)->NewStringUTF(env, cstr);
+
+    size_t blen = strlen(cstr);
+    // A UTF-16 unit consumes at least one input byte, so blen units suffice.
+    jchar *units = (jchar*)malloc((blen > 0 ? blen : 1) * sizeof(jchar));
+    if (units == NULL) {
+        throw_checked(env, "java/lang/OutOfMemoryError", "Failed to allocate UTF-16 buffer");
+        return NULL;
+    }
+
+    const unsigned char *in = (const unsigned char*)cstr;
+    size_t i = 0;
+    jsize o = 0;
+    while (i < blen) {
+        uint32_t cp;
+        unsigned char b = in[i];
+        if (b < 0x80) {
+            cp = b;
+            i += 1;
+        } else if ((b & 0xE0) == 0xC0 && i + 1 < blen && (in[i + 1] & 0xC0) == 0x80) {
+            cp = ((uint32_t)(b & 0x1F) << 6) | (in[i + 1] & 0x3F);
+            i += 2;
+            if (cp < 0x80) cp = 0xFFFD;  // Overlong
+        } else if ((b & 0xF0) == 0xE0 && i + 2 < blen &&
+                   (in[i + 1] & 0xC0) == 0x80 && (in[i + 2] & 0xC0) == 0x80) {
+            cp = ((uint32_t)(b & 0x0F) << 12) | ((uint32_t)(in[i + 1] & 0x3F) << 6) | (in[i + 2] & 0x3F);
+            i += 3;
+            if (cp < 0x800 || (cp >= 0xD800 && cp <= 0xDFFF)) cp = 0xFFFD;  // Overlong or surrogate
+        } else if ((b & 0xF8) == 0xF0 && i + 3 < blen &&
+                   (in[i + 1] & 0xC0) == 0x80 && (in[i + 2] & 0xC0) == 0x80 && (in[i + 3] & 0xC0) == 0x80) {
+            cp = ((uint32_t)(b & 0x07) << 18) | ((uint32_t)(in[i + 1] & 0x3F) << 12) |
+                 ((uint32_t)(in[i + 2] & 0x3F) << 6) | (in[i + 3] & 0x3F);
+            i += 4;
+            if (cp < 0x10000 || cp > 0x10FFFF) cp = 0xFFFD;  // Overlong or out of range
+        } else {
+            cp = 0xFFFD;  // Invalid lead byte or truncated sequence
+            i += 1;
+        }
+
+        if (cp >= 0x10000) {
+            cp -= 0x10000;
+            units[o++] = (jchar)(0xD800 + (cp >> 10));
+            units[o++] = (jchar)(0xDC00 + (cp & 0x3FF));
+        } else {
+            units[o++] = (jchar)cp;
+        }
+    }
+
+    jstring jstr = (*env)->NewString(env, units, o);
+    free(units);
     if (jstr == NULL) {
         check_exception(env);
     }

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -203,6 +203,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBuilderEmbeddableErrorPaths())
     results.add(builderTests.testContextProgressCallback())
     results.add(builderTests.testUnicodeManifestRoundTrip())
+    results.add(builderTests.testEmbeddedNulRejected())
     results.add(builderTests.testClosedHandleValidation())
     results.add(builderTests.testContextCloseDuringSign())
     results.add(builderTests.testContextHttpResolver())

--- a/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
+++ b/test-app/app/src/main/kotlin/org/contentauth/c2pa/testapp/TestScreen.kt
@@ -202,6 +202,7 @@ private suspend fun runAllTests(context: Context): List<TestResult> = withContex
     results.add(builderTests.testBmffMerkleHashing())
     results.add(builderTests.testBuilderEmbeddableErrorPaths())
     results.add(builderTests.testContextProgressCallback())
+    results.add(builderTests.testUnicodeManifestRoundTrip())
     results.add(builderTests.testClosedHandleValidation())
     results.add(builderTests.testContextCloseDuringSign())
     results.add(builderTests.testContextHttpResolver())

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -938,6 +938,34 @@ abstract class BuilderTests : TestBase() {
         }
     }
 
+    suspend fun testEmbeddedNulRejected(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Embedded NUL Rejected") {
+            // The JNI bridge hands the core NUL-terminated strings, so a Kotlin string
+            // containing U+0000 must be rejected at the boundary rather than silently
+            // truncated at the NUL.
+            var thrown: Throwable? = null
+            Builder.fromJson(TEST_MANIFEST_JSON).use { builder ->
+                try {
+                    builder.setRemoteURL("https://example.com/manifest\u0000.c2pa")
+                } catch (e: Throwable) {
+                    thrown = e
+                }
+            }
+
+            val success = thrown is IllegalArgumentException
+            TestResult(
+                "Embedded NUL Rejected",
+                success,
+                if (success) {
+                    "String containing U+0000 rejected with IllegalArgumentException"
+                } else {
+                    "Expected IllegalArgumentException, got: $thrown"
+                },
+                "Thrown: $thrown",
+            )
+        }
+    }
+
     suspend fun testUnicodeManifestRoundTrip(): TestResult = withContext(Dispatchers.IO) {
         runTest("Unicode Manifest Round Trip") {
             try {

--- a/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
+++ b/test-shared/src/main/kotlin/org/contentauth/c2pa/test/shared/BuilderTests.kt
@@ -938,6 +938,71 @@ abstract class BuilderTests : TestBase() {
         }
     }
 
+    suspend fun testUnicodeManifestRoundTrip(): TestResult = withContext(Dispatchers.IO) {
+        runTest("Unicode Manifest Round Trip") {
+            try {
+                // Supplementary-plane characters cross the JNI string bridge in both
+                // directions: into the manifest definition at sign time and back out of
+                // the manifest JSON at read time.
+                val title = "Unicode 🌍🎥 déjà vu ✓"
+                val manifestJson = """{
+                    "claim_generator": "test_app/1.0",
+                    "title": ${JSONObject.quote(title)},
+                    "assertions": [
+                        {
+                            "label": "c2pa.actions",
+                            "data": {
+                                "actions": [
+                                    {
+                                        "action": "c2pa.created",
+                                        "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCapture"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }"""
+
+                val certPem = loadResourceAsString("es256_certs")
+                val keyPem = loadResourceAsString("es256_private")
+                val sourceImageData = loadResourceAsBytes("pexels_asadphoto_457882")
+
+                val signedData = Builder.fromJson(manifestJson).use { builder ->
+                    ByteArrayStream(sourceImageData).use { source ->
+                        ByteArrayStream().use { dest ->
+                            Signer.fromInfo(SignerInfo(SigningAlgorithm.ES256, certPem, keyPem)).use { signer ->
+                                builder.sign("image/jpeg", source, dest, signer)
+                            }
+                            dest.getData()
+                        }
+                    }
+                }
+
+                val readTitle = ByteArrayStream(signedData).use { stream ->
+                    Reader.fromStream("image/jpeg", stream).use { reader ->
+                        val json = JSONObject(reader.json())
+                        val active = json.optString("active_manifest")
+                        json.getJSONObject("manifests").getJSONObject(active).optString("title")
+                    }
+                }
+
+                val success = readTitle == title
+                TestResult(
+                    "Unicode Manifest Round Trip",
+                    success,
+                    if (success) {
+                        "Supplementary-plane title round-tripped intact"
+                    } else {
+                        "Title mangled in round trip"
+                    },
+                    "Expected: $title\nActual: $readTitle",
+                )
+            } catch (e: Exception) {
+                TestResult("Unicode Manifest Round Trip", false, "Unicode round-trip flow threw", e.toString())
+            }
+        }
+    }
+
     suspend fun testClosedHandleValidation(): TestResult = withContext(Dispatchers.IO) {
         runTest("Closed Handle Validation") {
             // Calls on closed handles must be rejected with a typed exception at the


### PR DESCRIPTION
## Changes in this pull request
<!-- Give a description of what has changed -->

Replaces the modified-UTF-8 string bridging (GetStringUTFChars/NewStringUTF) with a UTF-16 transcode and explicit standard UTF-8 conversion in native code, so supplementary-plane characters like emoji survive the JNI boundary instead of being CESU-8-mangled inbound or hitting undefined behavior outbound. Confined entirely to the two string helpers — no call-site or Kotlin changes — with a round-trip test for a manifest title containing supplementary-plane characters.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment