### PR TITLE
Fix: JNI error path cleanup

### DIFF
--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -802,26 +802,52 @@ static int java_progress_callback(const void *context, enum C2paProgressPhase ph
 static int java_http_resolver_invoke(JNIEnv *env, JavaContextCallback *jctx,
                                      const struct C2paHttpRequest *request,
                                      struct C2paHttpResponse *response) {
-    jstring jurl = (request->url != NULL) ? cstring_to_jstring(env, request->url) : NULL;
-    jstring jmethod = (request->method != NULL) ? cstring_to_jstring(env, request->method) : NULL;
-    jstring jheaders = (request->headers != NULL) ? cstring_to_jstring(env, request->headers) : NULL;
+    // Marshal the request. Every JNI call here can fail with an exception
+    // pending (allocation failure, or a bridge string that the transcoder
+    // rejects); none of it may be left pending across the next JNI call, so
+    // each step is checked and stashed for the outer boundary.
+    jstring jurl = NULL, jmethod = NULL, jheaders = NULL;
     jbyteArray jbody = NULL;
-    if (request->body != NULL && request->body_len > 0 && request->body_len <= INT32_MAX) {
-        jbody = safe_new_byte_array(env, (jsize)request->body_len);
-        if (jbody != NULL) {
-            (*env)->SetByteArrayRegion(env, jbody, 0, (jsize)request->body_len, (const jbyte*)request->body);
+    const char *marshalError = "Failed to marshal HTTP request for resolver";
+    int marshalled = 0;
+    do {
+        if (request->url != NULL) {
+            jurl = cstring_to_jstring(env, request->url);
+            if (jurl == NULL) break;
         }
-    }
+        if (request->method != NULL) {
+            jmethod = cstring_to_jstring(env, request->method);
+            if (jmethod == NULL) break;
+        }
+        if (request->headers != NULL) {
+            jheaders = cstring_to_jstring(env, request->headers);
+            if (jheaders == NULL) break;
+        }
+        if (request->body != NULL && request->body_len > 0) {
+            if (request->body_len > INT32_MAX) {
+                marshalError = "HTTP request body too large for JNI";
+                break;
+            }
+            jbody = safe_new_byte_array(env, (jsize)request->body_len);
+            if (jbody == NULL) break;
+            (*env)->SetByteArrayRegion(env, jbody, 0, (jsize)request->body_len, (const jbyte*)request->body);
+            if ((*env)->ExceptionCheck(env)) break;
+        }
+        marshalled = 1;
+    } while (0);
 
-    // Bridge: resolve(String url, String method, String headers, byte[] body) -> HttpResponse
-    jobject jresp = (*env)->CallObjectMethod(env, jctx->callback, jctx->method, jurl, jmethod, jheaders, jbody);
+    jobject jresp = NULL;
+    if (marshalled) {
+        // Bridge: resolve(String url, String method, String headers, byte[] body) -> HttpResponse
+        jresp = (*env)->CallObjectMethod(env, jctx->callback, jctx->method, jurl, jmethod, jheaders, jbody);
+    }
     if (jurl != NULL) (*env)->DeleteLocalRef(env, jurl);
     if (jmethod != NULL) (*env)->DeleteLocalRef(env, jmethod);
     if (jheaders != NULL) (*env)->DeleteLocalRef(env, jheaders);
     if (jbody != NULL) (*env)->DeleteLocalRef(env, jbody);
 
     if (stash_pending_exception(env) || jresp == NULL) {
-        c2pa_error_set_last("HTTP resolver callback failed");
+        c2pa_error_set_last(marshalled ? "HTTP resolver callback failed" : marshalError);
         return -1;
     }
 
@@ -836,9 +862,20 @@ static int java_http_resolver_invoke(JNIEnv *env, JavaContextCallback *jctx,
         return -1;
     }
 
+    // Read the response back. The getters are app code and may throw.
     jint status = (*env)->CallIntMethod(env, jresp, getStatus);
+    if (stash_pending_exception(env)) {
+        (*env)->DeleteLocalRef(env, jresp);
+        c2pa_error_set_last("HttpResponse.getStatus failed");
+        return -1;
+    }
     jbyteArray respBody = (jbyteArray)(*env)->CallObjectMethod(env, jresp, getBody);
     (*env)->DeleteLocalRef(env, jresp);
+    if (stash_pending_exception(env)) {
+        if (respBody != NULL) (*env)->DeleteLocalRef(env, respBody);
+        c2pa_error_set_last("HttpResponse.getBody failed");
+        return -1;
+    }
 
     response->status = (int32_t)status;
     response->body = NULL;
@@ -854,6 +891,12 @@ static int java_http_resolver_invoke(JNIEnv *env, JavaContextCallback *jctx,
                 return -1;
             }
             (*env)->GetByteArrayRegion(env, respBody, 0, blen, (jbyte*)buf);
+            if (stash_pending_exception(env)) {
+                free(buf);
+                (*env)->DeleteLocalRef(env, respBody);
+                c2pa_error_set_last("Failed to copy HTTP response body");
+                return -1;
+            }
             response->body = buf;          // Rust takes ownership and frees with free()
             response->body_len = (uintptr_t)blen;
         }

--- a/library/src/main/jni/c2pa_jni.c
+++ b/library/src/main/jni/c2pa_jni.c
@@ -931,7 +931,7 @@ static int java_http_resolver_callback(void *context, const struct C2paHttpReque
 
 // Native methods implementation
 
-JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_C2PA_version(JNIEnv *env, jclass clazz) {
+JNIEXPORT jstring JNICALL Java_org_contentauth_c2pa_C2PA_versionNative(JNIEnv *env, jclass clazz) {
     char *version = c2pa_version();
     jstring result = cstring_to_jstring(env, version);
     c2pa_free(version);
@@ -1001,9 +1001,9 @@ JNIEXPORT jlong JNICALL Java_org_contentauth_c2pa_Stream_createStreamNative(JNIE
     );
     
     if (stream == NULL) {
+        // Sentinel return; the Kotlin constructor raises C2PAError from c2pa_error().
         (*env)->DeleteGlobalRef(env, ctx->streamObject);
         free(ctx);
-        throw_checked(env, "java/lang/RuntimeException", "Failed to create C2PA stream");
         return 0;
     }
     

--- a/library/src/main/kotlin/org/contentauth/c2pa/C2PA.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/C2PA.kt
@@ -25,11 +25,18 @@ object C2PA {
         loadC2PALibraries()
     }
 
+    @JvmStatic
+    private external fun versionNative(): String?
+
     /**
-     * Returns the version string of the C2PA library
+     * Returns the version string of the C2PA library.
+     *
+     * @throws C2PAError.Api if the version string cannot be retrieved
      */
     @JvmStatic
-    external fun version(): String
+    @Throws(C2PAError::class)
+    fun version(): String = versionNative()
+        ?: throw C2PAError.Api(C2PA.getError() ?: "Failed to get C2PA version")
 
     /**
      * Returns the last error message, if any

--- a/library/src/main/kotlin/org/contentauth/c2pa/Stream.kt
+++ b/library/src/main/kotlin/org/contentauth/c2pa/Stream.kt
@@ -33,7 +33,12 @@ typealias StreamWriter = (buffer: ByteArray, count: Int) -> Int
 
 typealias StreamFlusher = () -> Int
 
-/** Abstract base class for C2PA streams */
+/**
+ * Abstract base class for C2PA streams.
+ *
+ * Constructing a stream allocates a native handle; the constructor throws [C2PAError.Api] if the
+ * core cannot create it.
+ */
 abstract class Stream : Closeable {
 
     companion object {
@@ -47,7 +52,11 @@ abstract class Stream : Closeable {
         get() = nativeHandle
 
     init {
-        nativeHandle = createStreamNative()
+        val handle = createStreamNative()
+        if (handle == 0L) {
+            throw C2PAError.Api(C2PA.getError() ?: "Failed to create stream")
+        }
+        nativeHandle = handle
     }
 
     /** Read data from the stream */

--- a/test-shared/build.gradle.kts
+++ b/test-shared/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 28
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
## Changes in this pull request
<!-- Give a description of what has changed -->
Checks every JNI call in the HTTP resolver trampoline and routes the last two raw failure paths (Stream creation, C2PA.version()) through C2PAError, so nothing in the JNI throws RuntimeException or leaves an exception pending. Also aligns test-shared minSdk to 28.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment